### PR TITLE
Changed Maven URLs from http to https

### DIFF
--- a/rest-lib-utils/src/main/resources/vulas-rest-lib-utils.properties
+++ b/rest-lib-utils/src/main/resources/vulas-rest-lib-utils.properties
@@ -20,11 +20,11 @@
 
 # End point to retrieve artifacts from Maven Central
 # Default: 
-vulas.lib-utils.mavencentral.repo=http://repo1.maven.org/maven2/
+vulas.lib-utils.mavencentral.repo=https://repo1.maven.org/maven2/
 
 # Rest template to perform query searches in Maven Central
 # Default: 
-vulas.lib-utils.mavencentral.search=http://search.maven.org/solrsearch/select?q={q}&core={core}&rows={rows}&wt={wt}
+vulas.lib-utils.mavencentral.search=https://search.maven.org/solrsearch/select?q={q}&core={core}&rows={rows}&wt={wt}
 
 # Number of retries if [503] is received from Maven Central
 # Default: 


### PR DESCRIPTION
[Maven Central now requires HTTPS and forbids HTTP](https://support.sonatype.com/hc/en-us/articles/360041287334), which required to change a couple of URLs in the properties of `rst-lib-utils`

#### `TODO`s

- [x] Tests
- [ ] Documentation