### PR TITLE
Omit vulnerability exemptions in Surefire argLine setting

### DIFF
--- a/plugin-maven/src/main/java/com/sap/psr/vulas/mvn/VulasAgentMojo.java
+++ b/plugin-maven/src/main/java/com/sap/psr/vulas/mvn/VulasAgentMojo.java
@@ -113,8 +113,14 @@ public class VulasAgentMojo extends AbstractVulasMojo {
 					else {
 						val_str = val.toString();
 					}
-					this.agentOptions.put(key, val_str);
-					getLog().info("    [" + key + "=" + val + "]");
+					
+					// Do not include exemptions, as too many would result in error "The command line is too long."
+					if(key.startsWith(CoreConfiguration.REP_EXCL_BUGS)) {
+						getLog().warn("  Ignoring  [" + key + "=...]");
+					} else {
+						this.agentOptions.put(key, val_str);
+						getLog().info("    [" + key + "=" + val + "]");						
+					}
 				}
 			}
 			
@@ -137,8 +143,14 @@ public class VulasAgentMojo extends AbstractVulasMojo {
 						else {
 							val_str = val.toString();
 						}
-						this.agentOptions.put(key, val_str);
-						getLog().info("    [" + key + "=" + val + "]");
+						
+						// Do not include exemptions, as too many would result in error "The command line is too long."
+						if(key.startsWith(CoreConfiguration.REP_EXCL_BUGS)) {
+							getLog().warn("  Ignoring  [" + key + "=...]");
+						} else {
+							this.agentOptions.put(key, val_str);
+							getLog().info("    [" + key + "=" + val + "]");						
+						}
 					}
 				}
 			}


### PR DESCRIPTION
The Maven goal `prepare-vulas-agent` takes configuration settings and includes them in the Surefire argument `argLine`. If too many configuration settings are considered, this will lead to the Surefire error "The command line is too long". To prevent this, all exemption-related settings will not be included any more in `argLine`, they are anyways not needed during the instrumentation.

#### `TODO`s

- [ ] Tests
- [ ] Documentation