### PR TITLE
Avoid HTTP 500 error during CLEAN and APP goals

### DIFF
--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/model/Dependency.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/model/Dependency.java
@@ -64,10 +64,7 @@ import com.sap.psr.vulas.shared.enums.Scope;
 @JsonInclude(JsonInclude.Include.ALWAYS)
 @JsonIgnoreProperties(ignoreUnknown=true, value={"traced", "reachableConstructIds", "touchPoints"}, allowGetters=true)
 @Entity
-@Table( name="AppDependency")
-///uniqueConstraints=@UniqueConstraint( columnNames = { "lib" , "app"} )
-// Note, the unique constraint is not defined as an annotation any longer as we need more expressiveness than what JPA allows
-// The new constraints are defined in the flyway migration V20180828.1730__depParent.sql as partial indexes
+@Table( name="AppDependency", uniqueConstraints=@UniqueConstraint( columnNames = { "lib" , "app", "parent", "relativePath"} ))
 public class Dependency implements Serializable{
 	
 	private static final long serialVersionUID = 1L;

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/model/Dependency.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/model/Dependency.java
@@ -64,6 +64,8 @@ import com.sap.psr.vulas.shared.enums.Scope;
 @JsonInclude(JsonInclude.Include.ALWAYS)
 @JsonIgnoreProperties(ignoreUnknown=true, value={"traced", "reachableConstructIds", "touchPoints"}, allowGetters=true)
 @Entity
+// Note that the unique constraint at DB level (when using PostgreSQL) does not ensure the uniqueness of lib,app when parent
+// and relativePath are null as null values are considered different by PostgreSQL. Their uniqueness must be ensured at Java level
 @Table( name="AppDependency", uniqueConstraints=@UniqueConstraint( columnNames = { "lib" , "app", "parent", "relativePath"} ))
 public class Dependency implements Serializable{
 	

--- a/rest-backend/src/main/resources/db/migration/V20200219.1130__dropDepIndexes.sql
+++ b/rest-backend/src/main/resources/db/migration/V20200219.1130__dropDepIndexes.sql
@@ -1,0 +1,4 @@
+DROP INDEX if exists public.dep_app_lib_index;
+DROP INDEX if exists public.dep_app_lib_parent_index;
+DROP INDEX if exists public.dep_app_lib_relpath_index;
+alter table app_dependency add constraint UKnueog86fts45j2wcql6idbqwn unique (lib, app, parent, relative_path);


### PR DESCRIPTION
The 500 error was raised whenever CLEAN or APP was run on an application having multiple dependencies on the same library (same digest) having different parents. This probably happens with multi module applications where a module appears as direct dependency of another module and thus if APP is run without a CLEAN, the transitive dependencies gets duplicated with the newly built module as parent.

In such situation, before deleting the dependencies that do not exist any longer (all in the case of a CLEAN), JPA triggers an SQL update on such dependencies to set the parent to null. 

This causes a constraint violation exception as we enforced at db level that app and lib must be unique whenever the parent and relativePath are null.  

This constraint was created (together with other 2 constraints) to make the 4-tuple app, lib, parent, relativePath unique. We didn't simply create the constraint on the 4-tuple as parent and relativePath are nullable and thus postgres would allow the following two rows to exist:

app1, lib1 ,null,null
app1,lib1, null, null

However the mistmatch between the constraint at db and java level causes errors like the one observed. As a consequence I would suggest to replace the existing constraints at db level with the one on the 4-tuple. This means that the db would allow the above rows to be stored but this should be prevented at Java level (it is actually the client that would never generate such dependencies).


#### `TODO`s

- [ ] Tests
- [ ] Documentation