### PR TITLE
Adjust log levels

### DIFF
--- a/lang-java/src/main/java/com/sap/psr/vulas/java/ArchiveAnalysisManager.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/ArchiveAnalysisManager.java
@@ -332,9 +332,9 @@ public class ArchiveAnalysisManager {
 				}
 				// There are remaining tasks, but no timeout is set or reached
 				else if(!open_tasks.isEmpty()) {
-					ArchiveAnalysisManager.log.info("Waiting for the completion of [" + open_tasks.size() + "] analysis tasks:");
+					ArchiveAnalysisManager.log.info("Waiting for the completion of [" + open_tasks.size() + "] analysis tasks");
 					for(JarAnalyzer ja: open_tasks.keySet())
-						ArchiveAnalysisManager.log.info("    " + ja);
+						ArchiveAnalysisManager.log.debug("    " + ja);
 				}
 			}
 			

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/ConditionalHttpRequest.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/ConditionalHttpRequest.java
@@ -109,20 +109,20 @@ public class ConditionalHttpRequest extends BasicHttpRequest {
 			for(ResponseCondition rc: this.conditions) {
 				meets = meets && rc.meetsCondition(condition_response);
 				if(!meets) {
-					ConditionalHttpRequest.log.info("Condition " + rc + " not met");
+					ConditionalHttpRequest.log.debug("Condition " + rc + " not met");
 					break;
 				} else {
-					ConditionalHttpRequest.log.info("Condition " + rc + " met");
+					ConditionalHttpRequest.log.debug("Condition " + rc + " met");
 				}
 			}
 
 			// Only send if they are met
 			if(meets) {
-				ConditionalHttpRequest.log.info("Condition(s) met, do " + this.toString());
+				ConditionalHttpRequest.log.debug("Condition(s) met, do " + this.toString());
 				return super.send();
 			}
 			else {
-				ConditionalHttpRequest.log.info("Condition(s) not met, skip " + this.toString());
+				ConditionalHttpRequest.log.debug("Condition(s) not met, skip " + this.toString());
 				return null;
 			}	
 		}	

--- a/lang/src/main/java/com/sap/psr/vulas/malice/ZipSlipAnalyzer.java
+++ b/lang/src/main/java/com/sap/psr/vulas/malice/ZipSlipAnalyzer.java
@@ -148,7 +148,7 @@ public class ZipSlipAnalyzer implements MaliciousnessAnalyzer {
 		} else {
 			mal.setReason("Archive is NOT subject to ZipSlip vulnerability, all [" + count + "] archive entries would be extracted inside or below an intended target folder");
 			if(_log)
-				log.info(mal.getReason());
+				log.debug(mal.getReason());
 		}
 		
 		return mal;

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/ApplicationRepositoryImpl.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/ApplicationRepositoryImpl.java
@@ -495,7 +495,7 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
 		// 1) Join over construct changes (origin=cc)
 		final TreeSet<VulnerableDependency> vd_list_cc = this.appRepository.findJPQLVulnerableDependenciesByGAV(_app.getMvnGroup(), _app.getArtifact(), _app.getVersion(), _app.getSpace());
 		if(_log)
-			sw.lap("Found [" + vd_list_cc.size() + "] through joining constructs", true);
+			sw.lap("Found [" + vd_list_cc.size() + "] through joining constructs");
 		
 		//to improve performances we use a native query to get the affected version (having moved to SQL the computation of the affected version source having priority.
 		//further improvements could be:
@@ -509,7 +509,8 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
 		
 		List<Object[]> bundledDigests = this.libRepository.findBundledLibByApp(_app);
 		
-		log.info("Found ["+bundledDigests.size()+"] libs digest for bundled libids.");
+		if(_log)
+			sw.lap("Found ["+bundledDigests.size()+"] libs digest for bundled libids.");
 		
 		for (Object[] e: bundledDigests){
 			Dependency depWithBundledLibId = DependencyRepository.FILTER.findOne(this.depRepository.findById(((BigInteger)e[0]).longValue()));
@@ -571,8 +572,8 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
 		}
 		
 		if(_log){
-			sw.lap("Found [" + vd_list_bundled_cc.size() + "] vulns w/  cc through bundled library ids", true);
-			sw.lap("Found [" + vd_list_bundled_av.size() + "] vulns w/o cc through bundled library ids", true);
+			sw.lap("Found [" + vd_list_bundled_cc.size() + "] vulns w/  cc through bundled library ids");
+			sw.lap("Found [" + vd_list_bundled_av.size() + "] vulns w/o cc through bundled library ids");
 		}
 
 
@@ -591,7 +592,7 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
 		}
 		vd_list_libid.addAll(vd_list_libid_false);
 		if(_log)
-			sw.lap("Found [" + vd_list_libid.size() + "] through joining libids", true);
+			sw.lap("Found [" + vd_list_libid.size() + "] through joining libids");
 		//this.affLibRepository.computeAffectedLib(vd_list_libid); this is not required for vulns w/o cc as we select by affectedVersions.affected (in this way we save the additional queries to get the affected flag afterwards)
 		this.updateFlags(vd_list_libid, false);
 
@@ -739,7 +740,7 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
 			listOfConstructs.add(cc.getConstructId());
 		}
 		List<Application> apps = appRepository.findAppsByCC(listOfConstructs); 
-		sw.lap("LastVulnChange by CC, [" +apps.size()+"] apps to be refreshed",true);
+		sw.lap("LastVulnChange by CC, [" +apps.size()+"] apps to be refreshed");
 
 		//we partition the list to work around the PostgreSQL's limit of 32767 bind variables per statement
 		for(List<Application> sub: Lists.partition(apps, 30000))
@@ -756,7 +757,7 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
 			if(_affLib.getAffected()!=null)
 				apps.addAll(appRepository.findAppsByAffLib(_affLib.getLibraryId()));
 		}
-		sw.lap("LastVulnChange by AffLib, [" +apps.size()+"] apps to be refreshed", true);
+		sw.lap("LastVulnChange by AffLib, [" +apps.size()+"] apps to be refreshed");
 		//we partition the list to work around the PostgreSQL's limit of 32767 bind variables per statement
 		for(List<Application> sub: Lists.partition(apps, 30000))
 			appRepository.updateAppLastVulnChange(sub);

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/BugRepositoryImpl.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/BugRepositoryImpl.java
@@ -206,13 +206,13 @@ public class BugRepositoryImpl implements BugRepositoryCustom {
 					
 					// Something changed, update database
 					if(to_save) {
-						log.info("CVE data of bug [" + _b.getBugId() + "] changed, triggering update of local database");
+						log.debug("CVE data of bug [" + _b.getBugId() + "] changed, triggering update of local database");
 						this.customSave(_b, false);
 						update_happened = true;
 					}
 					// Nothing changed
 					else {
-						log.info("CVE data of bug [" + _b.getBugId() + "] did not change, no update of local database needed");
+						log.debug("CVE data of bug [" + _b.getBugId() + "] did not change, no update of local database needed");
 					}
 				}
 			} catch (CacheException e) {

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryRepositoryImpl.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryRepositoryImpl.java
@@ -108,7 +108,7 @@ public class LibraryRepositoryImpl implements LibraryRepositoryCustom {
 			}
 					
 		} catch(EntityNotFoundException e1) {			
-			LibraryRepositoryImpl.log.info("Library [" + _lib.getDigest() + "] does not yet exist, going to save it.");
+			LibraryRepositoryImpl.log.debug("Library [" + _lib.getDigest() + "] does not yet exist, going to save it.");
 		}
 		
 		// Retrieve libId from Maven if digest verified
@@ -170,16 +170,16 @@ public class LibraryRepositoryImpl implements LibraryRepositoryCustom {
 	public Library saveIncomplete(Library _lib) throws PersistenceException {
 		Library incomplete = new Library(_lib.getDigest());
 		if (_lib.getLibraryId()!=null){
-			LibraryRepositoryImpl.log.info("Setting library Id ["+_lib.getLibraryId().toString()+"] of incomplete library [" +_lib.getDigest()+ "]");
+			LibraryRepositoryImpl.log.debug("Setting library Id ["+_lib.getLibraryId().toString()+"] of incomplete library [" +_lib.getDigest()+ "]");
 			incomplete.setLibraryId(_lib.getLibraryId());
 		}
 		else
 			incomplete.setLibraryId(null);
 		
 		if(_lib.getConstructs()!=null)
-			LibraryRepositoryImpl.log.info("Library ["+_lib.getDigest()+"] to be saved has [" +_lib.getConstructs().size()+"] constructs");
+			LibraryRepositoryImpl.log.debug("Library ["+_lib.getDigest()+"] to be saved has [" +_lib.getConstructs().size()+"] constructs");
 		if(_lib.getProperties()!=null)
-			LibraryRepositoryImpl.log.info("Library ["+_lib.getDigest()+"] to be saved has [" +_lib.getProperties().size()+"] properties");
+			LibraryRepositoryImpl.log.debug("Library ["+_lib.getDigest()+"] to be saved has [" +_lib.getProperties().size()+"] properties");
 		
 		try{
 			return this.libRepository.save(incomplete);

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/SpaceRepositoryImpl.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/SpaceRepositoryImpl.java
@@ -69,7 +69,7 @@ public class SpaceRepositoryImpl implements SpaceRepositoryCustom {
 			//	_s.setSpaceOwners(managed_space.getSpaceOwners());
 			
 		} catch (EntityNotFoundException e1) {			
-			SpaceRepositoryImpl.log.info("Space [" + _s.getSpaceToken() + "] does not yet exist, going to save it.");
+			SpaceRepositoryImpl.log.debug("Space [" + _s.getSpaceToken() + "] does not yet exist, going to save it.");
 		}
 		
 		// Update refs to independent entities
@@ -136,7 +136,7 @@ public class SpaceRepositoryImpl implements SpaceRepositoryCustom {
 			}
 		}
 		
-		log.info("Found " + space + " for token [" + _spaceToken + "]");
+		log.debug("Found " + space + " for token [" + _spaceToken + "]");
 		return space;
 	}
 }

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/TenantRepositoryImpl.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/TenantRepositoryImpl.java
@@ -97,7 +97,7 @@ public class TenantRepositoryImpl implements TenantRepositoryCustom {
 			}
 		}
 		
-		log.info("Found " + tenant + " for token [" + _tenantToken + "]");
+		log.debug("Found " + tenant + " for token [" + _tenantToken + "]");
 		return tenant;
 	}
 }

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/rest/ApplicationController.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/rest/ApplicationController.java
@@ -749,7 +749,7 @@ public class ApplicationController {
 			return new ResponseEntity<Set<ConstructSearchResult>>(HttpStatus.NOT_FOUND);
 		}
 		catch(Exception e) {
-			log.info("Error while searching for constructs in dependencies of app " + app + ": " + e.getMessage());
+			log.error("Error while searching for constructs in dependencies of app " + app + ": " + e.getMessage());
 			return new ResponseEntity<Set<ConstructSearchResult>>(HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 	}
@@ -1140,7 +1140,7 @@ public class ApplicationController {
 			try {
 				this.gexeRepository.delete(gexe);
 			} catch (Exception e) {
-				log.info("Error while deleting goal execution " + gexe + ": " + e.getMessage());
+				log.error("Error while deleting goal execution " + gexe + ": " + e.getMessage());
 			}
 		}
 		return new ResponseEntity<List<GoalExecution>>(HttpStatus.OK);
@@ -1461,7 +1461,7 @@ public class ApplicationController {
 							if(jdr.isDeleted(tp.getTo().toSharedType())) {
 								deleted_callees.add(tp.getTo());
 								ratio_callers_to_modify.incrementCount();
-								log.info("Touch point callee " + tp.getTo().toString() + " deleted from " + dep.getLib().getLibraryId().toString() + " to " + otherVersion);
+								log.debug("Touch point callee " + tp.getTo().toString() + " deleted from " + dep.getLib().getLibraryId().toString() + " to " + otherVersion);
 							}
 						}
 					}
@@ -1607,7 +1607,7 @@ public class ApplicationController {
 					if(tp.getDirection()==TouchPoint.Direction.A2L) {
 						if(jdr.isDeleted(tp.getTo().toSharedType())) {
 							callsToModify.add(tp);
-							log.info("Touch point callee " + tp.getTo().toString() + " deleted from " + dep.getLib().getLibraryId().toString() + " to " + otherVersion);
+							log.debug("Touch point callee " + tp.getTo().toString() + " deleted from " + dep.getLib().getLibraryId().toString() + " to " + otherVersion);
 						}
 					}
 				}


### PR DESCRIPTION
Following the possibility to better configure the log level threshold with system property `vulas.log4j.threshold` (#339), this PR is used to adjust the level of logging statements both in client and server components.

#### `TODO`s

- [ ] Tests
- [ ] Documentation