### PR TITLE
increase muffet url timeout

### DIFF
--- a/docs/checklinks.sh
+++ b/docs/checklinks.sh
@@ -20,24 +20,5 @@ fi
        -e .*wala\.sourceforge\.net.* \
        -e .*stackoverflow\.com.* \
        -e .*github\.com/kubernetes/ingress-nginx.* \
-       -e .*wiki.jenkins.io.* \
-       -t 20 http://$URL
+       -t 80 http://$URL
 
-
-# wiki.jenkins.io responds very slowly so it has its own timeout
-# this mediates the issue with checklinks stage of travis job failing
-# at seemingly random intervals
-
-./muffet -e .*/edit/.* \
-       -e .*/f2895a6e-ca7c-0010-82c7-eda71af511fa.html \
-       -e .*exploit-db\.com \
-       -e .*corp[/:].* \
-       -e .*:8033/.* \
-       -e .*/apps.* \
-       -e .*/bugs.* \
-       -e .*maven\.apache\.org.* \
-       -e .*docs\.oracle\.com.* \
-       -e .*wala\.sourceforge\.net.* \
-       -e .*stackoverflow\.com.* \
-       -e .*github\.com/kubernetes/ingress-nginx.* \
-       -e ^.*wiki.jenkins.io.* -t 80 http://$URL

--- a/docs/checklinks.sh
+++ b/docs/checklinks.sh
@@ -20,5 +20,6 @@ fi
        -e .*wala\.sourceforge\.net.* \
        -e .*stackoverflow\.com.* \
        -e .*github\.com/kubernetes/ingress-nginx.* \
+       -e .*\.apache\.org.* \
        -t 80 http://$URL
 


### PR DESCRIPTION
Unified timeout duration in checklink.sh and increased it to 80.

This may increase the overall time of the docs build phase if an URL is broken but is worth it because it helps avoid random failure of the build process.

_Duplicated PR due to requirement that all commit are signed_