### PR TITLE
Updated Gradle tutorial

### DIFF
--- a/docs/public/content/user/tutorials/java_gradle.md
+++ b/docs/public/content/user/tutorials/java_gradle.md
@@ -3,11 +3,10 @@
 ## Prerequisites
 
 1. JDK 7 or later
-2. URL of the package repository to download the plugin JAR (`@@PACKAGE_REPO@@`)
-3. URLs of the **backend service** and **apps Web frontend**
+2. URLs of the **backend service** and **apps Web frontend**
     - Apps Web frontend: @@ADDRESS@@/apps
     - Backend service: @@ADDRESS@@/backend/
-4. The token of a @@PROJECT_NAME@@ workspace
+3. The token of a @@PROJECT_NAME@@ workspace
 
 {! user/tutorials/partials/create_workspace.md !}
 
@@ -20,7 +19,6 @@ The plugin for Gradle requires changes of the following two files:
 ```gradle
     buildscript {
         repositories {
-            maven { url '@@PACKAGE_REPO@@' }
             mavenCentral()
         }
 
@@ -52,7 +50,7 @@ Note: Rather than adding configuration settings to `gradle.properties`, they can
 The configuration is correct if the @@PROJECT_NAME@@ analysis goals `app`, `a2c` etc. are listed among **Other tasks** when running the following command:
 
 ```sh
-    ./gradlew tasks -all
+    ./gradlew tasks --all
 ```
 
 The Gradle plugin only works with later releases of Gradle. How to upgrade is described [here](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:upgrading_wrapper).


### PR DESCRIPTION
The Gradle tutorial and configuration snippets could be shortened now that Steady artifacts are available on Maven Central.

#### `TODO`s

- [ ] Tests
- [X] Documentation