### PR TITLE
Fix missing dependency on parent

### DIFF
--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/model/Application.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/model/Application.java
@@ -306,7 +306,8 @@ public class Application implements Serializable, Comparable {
 	}
 
 	/**
-	 * <p>orderDependenciesByDepth.</p>
+	 * <p>Orders the collection <code>dependencies</code> from the shallowest (i.e., direct dependencies that do not have any parent) to the deepest (i.e., the dependencies having the longest chain of parents).</p>
+	 * 
 	 */
 	public void orderDependenciesByDepth(){
 		//order dependencies by length of parents

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/ApplicationRepositoryImpl.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/ApplicationRepositoryImpl.java
@@ -140,7 +140,7 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
 			_app = this.updateDependencies(managed_app, _app);
 			sw.lap("Updated refs to nested deps of existing application' dependencies");
 		} catch (EntityNotFoundException e1) {
-			//if the applcation does not exist, we create an empty one so that we can later add the dependencies incrementally
+			//if the application does not exist, we create an empty one so that we can later add the dependencies incrementally
 			Application new_app = new Application(group,artifact,version);
 			new_app.setSpace(_app.getSpace());
 			managed_app = this.appRepository.save(new_app);		
@@ -162,10 +162,10 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
 		
 		
 		_app.orderDependenciesByDepth();
-		_app = this.saveAndupdateDependencyTree(_app);
+		_app = this.saveDependencyTree(_app);
 		sw.lap("Saved and updated refs to dependencies' (including parents)");
 		
-		// Save (if existing, saves the updated fields, otherwise iti should all already be there
+		// Save (if existing, saves the updated fields, otherwise it should all already be there)
 		try {
 			managed_app = this.appRepository.save(_app);
 			sw.stop();
@@ -177,19 +177,32 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
 		return managed_app;
 	}
 	
-	private Application saveAndupdateDependencyTree(@NotNull Application _app) {
+	/**
+	 * <p>Saves the dependency tree ensuring that no transient entities are used for parent dependencies. This is done by setting the parent with 
+	 *  its already saved entity. Note that after the save operation the entity is still just handled by Hibernate and may not be persisted in the database yet. 
+	 *  Still the handling of Hibernate ensures that once persisted the id will be set correctly linking the parent to its entity).</p>
+	 * 
+	 * @return a  {@link com.sap.psr.vulas.backend.model.Application} object.
+	 */
+	private Application saveDependencyTree(@NotNull Application _app) {
 		for(Dependency d: _app.getDependencies()) { 
 			if(d.getParent()!=null){
-				d.setParent(updateParent(d.getParent(),_app));
+				d.setParent(getManagedParent(d.getParent(),_app));
 			}
 			d = this.depRepository.save(d);
 		}
 		return _app;
 	}	
 	
-	private Dependency updateParent(Dependency _dep,Application _app){
+	/**
+	 * <p> Given a dependency parent <code>_dep</code>, it retrieves the dependency within the plain list of  all dependencies of the application <code>_app</code>.
+	 * 	Because of how dependencies are saved, this operation amounts to retrieve the managed dependency (with id) corresponding to the provided one <code>_dep</code>.</p>
+	 * 
+	 * @return a  {@link com.sap.psr.vulas.backend.model.Dependency} object.
+	 */
+	private Dependency getManagedParent(Dependency _dep,Application _app){
 		if(_dep.getParent()!=null)
-			_dep.setParent(updateParent(_dep.getParent(),_app));
+			_dep.setParent(getManagedParent(_dep.getParent(),_app));
 		
 		for(Dependency d:_app.getDependencies()) {
 			if(d.equalLibParentRelPath(_dep))
@@ -199,6 +212,11 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
 	}
 	
 	
+	/**
+	 * <p>Updates the provided dependencies of the provided application with managed ones of the managed application if the same dependency exists in both.</p>
+	 * 
+	 * @return a  {@link com.sap.psr.vulas.backend.model.Application} object.
+	 */
 	private Application updateDependencies(@NotNull Application _managed_app, @NotNull Application _provided_app) {
 		for(Dependency provided_dep: _provided_app.getDependencies()) {
 			for(Dependency managed_dep: _managed_app.getDependencies()) {

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/ApplicationRepositoryImpl.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/ApplicationRepositoryImpl.java
@@ -188,17 +188,14 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
 	}	
 	
 	private Dependency updateParent(Dependency _dep,Application _app){
-
 		if(_dep.getParent()!=null)
 			_dep.setParent(updateParent(_dep.getParent(),_app));
-		try{		
-			_dep = DependencyRepository.FILTER.findOne(depRepository.findByAppAndLibAndParentAndRelPath(_app, _dep.getLib().getDigest(),_dep.getParent(),_dep.getRelativePath()));			
-		}catch(EntityNotFoundException e){
-			//this should not happen, as we ordered the list, when we came across a parent it should have been already saved
-			log.warn("Parent entity not already existing");
-			_dep=this.depRepository.save(_dep);
+		
+		for(Dependency d:_app.getDependencies()) {
+			if(d.equalLibParentRelPath(_dep))
+				return d;
 		}
-		return _dep;
+		throw new PersistenceException("Error while saving parent dependency on lib " + _dep.getLib() + "] of application " + _app + ": parent does not exist in application collection");
 	}
 	
 	

--- a/rest-backend/src/test/java/com/sap/psr/vulas/backend/rest/ApplicationControllerTest.java
+++ b/rest-backend/src/test/java/com/sap/psr/vulas/backend/rest/ApplicationControllerTest.java
@@ -462,6 +462,13 @@ public class ApplicationControllerTest {
     	// Repo must contain 1
     	assertEquals(1, this.appRepository.count());
     	
+
+       	final MockHttpServletRequestBuilder get_builder = get(getAppUri(app)+"/deps");
+    	mockMvc.perform(get_builder)	
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(contentTypeJson))
+                .andExpect(jsonPath("$[1].parent.lib.digest", is("16CF5A6B78951F50713D29BFAE3230A611DC01F0")));
+ 
     }
     
     @Test


### PR DESCRIPTION
Bug observed:
The exception
"EntityNotFoundException: Unable to find com.sap.psr.vulas.backend.model.Dependency with id XYZ"
was triggered when retrieving an application from the db in case the parent of a dependency contained the id of a dependency not existing anylonger. The DB allowed such a case as we removed the foreign key between the column parent and the dependency table for performance reasons.

What do we know:
Most likely, this bug is due to the way we were saving dependencies which relied on the db. To link a dependency to its parent, the latter needs to exists so that the link can be established based on the hibernate id. To save the dependencies we were using the "save" method of the CrudRepository, Later on, when setting the parents, we were looking in the db (via a JPQL query) to get the correct dependency to be linked. If that was not existing, we were saving it on the spot, however this should have never happened as the dependency were saved starting from the shallowest. 
The problem relies on the fact that the "save" method does not persist the changes in the DB, it's up to hibernate to decide when to persist changes within a transaction and, ultimately, at the end of the transaction. This also caused the multiplication of dependencies (the same dependency was appearing multiple times , even 20+) as it was saved every time it was referenced as parent. I think that the "missing dependency" originates from the fact that while saving we are able to retrieve the "old" dependency before the orphan removal takes place. Of course i was not able to test it as it is strictly linked to the current load and how hibernate handles the on-going transactions.

Alternatives: One solution would be to force hibernate to persist the changes within the transaction, i.e., to call "saveandflush" of the JPARepository. However i thought it was safer to still let hibernate handle the interaction with the db and i modified the code to create the dependency tree using the entities in memory rather than retrieving them from the db.

