### PR TITLE
Get affected libraries for well known artifacts

### DIFF
--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/AffectedLibraryRepository.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/AffectedLibraryRepository.java
@@ -72,6 +72,18 @@ public interface AffectedLibraryRepository extends CrudRepository<AffectedLibrar
 	List<AffectedLibrary> findByBugAndSource(@Param("bug") Bug bug, @Param("source") AffectedVersionSource source);
 	
 	/**
+	 * For a given {@link Bug} and {@link AffectedVersionSource}, find all entries that are linked to a library whose digest is well known. 
+	 *
+	 * @param bug a {@link com.sap.psr.vulas.backend.model.Bug} object.
+	 * @param source a {@link com.sap.psr.vulas.shared.enums.AffectedVersionSource} object.
+	 * @return a {@link java.util.List} object.
+	 */
+	@Query("SELECT afflib FROM AffectedLibrary AS afflib JOIN afflib.libraryId lid, Library l "
+			+ "WHERE l.libraryId=lid AND l.wellknownDigest='true' AND"
+			+ " afflib.bugId = :bug AND afflib.source = :source")
+	List<AffectedLibrary> findWellKnownByBugAndSource(@Param("bug") Bug bug, @Param("source") AffectedVersionSource source);
+	
+	/**
 	 * <p>findByBugAndLibIdAndSource.</p>
 	 *
 	 * @param bug a {@link com.sap.psr.vulas.backend.model.Bug} object.
@@ -113,6 +125,18 @@ public interface AffectedLibraryRepository extends CrudRepository<AffectedLibrar
 	 */
 	@Query("SELECT afflib FROM AffectedLibrary AS afflib WHERE afflib.bugId = :bug")
 	List<AffectedLibrary> findByBug(@Param("bug") Bug bug);
+	
+	/**
+	 * For a given {@link Bug} and {@link AffectedVersionSource}, find all entries that are linked to a library whose digest is well known. 
+	 *
+	 * @param bug a {@link com.sap.psr.vulas.backend.model.Bug} object.
+	 * @param source a {@link com.sap.psr.vulas.shared.enums.AffectedVersionSource} object.
+	 * @return a {@link java.util.List} object.
+	 */
+	@Query("SELECT afflib FROM AffectedLibrary AS afflib JOIN afflib.libraryId lid, Library l "
+			+ "WHERE l.libraryId=lid AND l.wellknownDigest='true' AND"
+			+ " afflib.bugId = :bug")
+	List<AffectedLibrary> findWellKnownByBug(@Param("bug") Bug bug);
 	
 	
 	/**

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/AffectedLibraryRepositoryCustom.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/AffectedLibraryRepositoryCustom.java
@@ -26,6 +26,7 @@ import com.sap.psr.vulas.backend.model.AffectedLibrary;
 import com.sap.psr.vulas.backend.model.Bug;
 import com.sap.psr.vulas.backend.model.Library;
 import com.sap.psr.vulas.backend.model.VulnerableDependency;
+import com.sap.psr.vulas.shared.enums.AffectedVersionSource;
 
 /**
  * Specifies additional methods of the {@link AffectedLibraryRepository}.
@@ -55,4 +56,14 @@ public interface AffectedLibraryRepositoryCustom {
 	 * @param _lib a {@link com.sap.psr.vulas.backend.model.Library} object.
 	 */
 	public void computeAffectedLib(VulnerableDependency _vd, Library _lib);
+	
+	/**
+	 * <p>Get affected libraries.</p>
+	 *
+	 * @param _bug a {@link com.sap.psr.vulas.backend.model.Bug} object.
+	 * @param _source a {@link com.sap.psr.vulas.shared.enums.AffectedVersionSource} object.
+	 * @param _onlyWellknown a {@link java.lang.Boolean} object. 
+	 * @return a {@link java.util.List} object.
+	 */
+	public List<AffectedLibrary> getAffectedLibraries(Bug _bug, AffectedVersionSource _source, Boolean _onlyWellknown);
 }

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/AffectedLibraryRepositoryImpl.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/AffectedLibraryRepositoryImpl.java
@@ -33,6 +33,8 @@ import javax.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 import com.sap.psr.vulas.backend.model.AffectedConstructChange;
 import com.sap.psr.vulas.backend.model.AffectedLibrary;
@@ -42,6 +44,7 @@ import com.sap.psr.vulas.backend.model.ConstructId;
 import com.sap.psr.vulas.backend.model.Library;
 import com.sap.psr.vulas.backend.model.LibraryId;
 import com.sap.psr.vulas.backend.model.VulnerableDependency;
+import com.sap.psr.vulas.shared.enums.AffectedVersionSource;
 import com.sap.psr.vulas.shared.util.StopWatch;
 
 /**
@@ -265,5 +268,16 @@ public class AffectedLibraryRepositoryImpl implements AffectedLibraryRepositoryC
 			_vd.setAffectedVersionConfirmed(0);
 			_vd.setAffectedVersion(1); // when the confirmed flag is 0, the value of affected-version is irrelevant but we set it to 1 so that the UI doesn't filter it out when filtering out historical vulnerabilities
 		}
+	}
+	
+	public List<AffectedLibrary> getAffectedLibraries(Bug _bug, AffectedVersionSource _source, Boolean _onlyWellknown){
+		if(_source==null && !_onlyWellknown)
+			return this.affLibRepository.findByBug(_bug);
+		else if (_source!=null && !_onlyWellknown)
+			return this.affLibRepository.findByBugAndSource(_bug, _source);
+		else if(_source!=null && _onlyWellknown)
+			return this.affLibRepository.findWellKnownByBugAndSource(_bug, _source);
+		else 
+			return this.affLibRepository.findWellKnownByBug(_bug);
 	}
 }

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/rest/BugController.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/rest/BugController.java
@@ -376,14 +376,13 @@ public class BugController {
 	 */
 	@RequestMapping(value = "/{bugid}/affectedLibIds", method = RequestMethod.GET, produces = {"application/json;charset=UTF-8"})
 	@JsonView(Views.BugAffLibs.class)
-	public ResponseEntity<List<AffectedLibrary>> getAllAffectedLibraries(@PathVariable String bugid, @RequestParam(value="source", required=false) AffectedVersionSource source) {
+	public ResponseEntity<List<AffectedLibrary>> getAllAffectedLibraries(@PathVariable String bugid, 
+			@RequestParam(value="source", required=false) AffectedVersionSource source,
+			@RequestParam(value="onlyWellKnown", required=false, defaultValue="false") Boolean onlyWellknown) {
 		Bug bug = null;
 		try { bug = BugRepository.FILTER.findOne(this.bugRepository.findByBugId(bugid)); }
 		catch (EntityNotFoundException e) { return new ResponseEntity<List<AffectedLibrary>>(HttpStatus.NOT_FOUND); }
-		if(source==null)
-			return new ResponseEntity<List<AffectedLibrary>>(this.afflibRepository.findByBug(bug), HttpStatus.OK);
-		else
-			return new ResponseEntity<List<AffectedLibrary>>(this.afflibRepository.findByBugAndSource(bug, source), HttpStatus.OK);
+		return new ResponseEntity<List<AffectedLibrary>>(this.afflibRepository.getAffectedLibraries(bug, source, onlyWellknown), HttpStatus.OK);
 	}
 	
 	/**


### PR DESCRIPTION
This PR enhances the rest endpoint GET /bugs/{bugId}/affectedLibIds. This endpoints returns all affectedLibraries for a given bug. However, in the case of affected libraries linked to libraryIds (GAVs), it may be the case that the GAVs is associated to libraries (digests) that are not publicly available, i.e., that are not well known (In the steady implementation, the field wellknownDigest is true if the archive digest is known in the configured maven repository, Maven Central by default).

The newly added querystring parameter 'onlyWellknown' allows to get affectedLibraries for the set of library ids that are linked to libraries that have the flag wellknownDigest=true.