### PR TITLE
Restrict condition for bundled Libraries

### DIFF
--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryRepository.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryRepository.java
@@ -299,12 +299,19 @@ public interface LibraryRepository extends CrudRepository<Library, Long>, Librar
 	@Query("SELECT l FROM Library l WHERE l.libraryId =:bundledLibId")
 	List<Library> findByLibraryId(@Param("bundledLibId") LibraryId bundledLibId);
 
+	/**
+	 * <p>Finds libraries that are rebundled in an application dependency. It returns a list of pairs dependency, bundled library.
+	 *  Note that bundled libraries must have a digest and a GAV different from the one of the dependency rebundling it.</p>
+	 *
+	 * @param app a {@link com.sap.psr.vulas.backend.model.Application} object.
+	 * @return a {@link java.util.List} object.
+	 */
 	@Query(value="select distinct d.id as dep_id, l2.id as bundled_lib_id"
 			+ "   from app_dependency d "
-			+ "   inner join lib l1 on d.lib=l1.digest "
-			+ "   inner join lib_bundled_library_ids bl on l1.id=bl.library_id "
+			+ "   inner join lib l1 on d.lib=l1.digest inner join library_id lid1 on l1.library_id_id =lid1.id "
+			+ "   inner join lib_bundled_library_ids bl on l1.id=bl.library_id inner join library_id lid2 on bl.bundled_library_ids_id=lid2.id "
 			+ "   inner join lib l2 on bl.bundled_library_ids_id=l2.library_id_id "
-			+ "   where d.app=:app and not l1.id = l2.id and l2.wellknown_digest='true'  ", nativeQuery=true)
+			+ "   where d.app=:app and not l1.id = l2.id and l2.wellknown_digest='true' and not lid1.id=lid2.id", nativeQuery=true)
 	List<Object[]> findBundledLibByApp(@Param("app") Application app);
 
 }


### PR DESCRIPTION
This PR modifies the native query that select bundled libraries. Given an application, the query returns pairs dependency, (bundled) library. 

Problem observed:
Vulnerabilities reported ONLY for a bundled GAVs equal to the GAV of the dependency itself. E.g., CVE1 reported for GAV org.a:project-b:0 bundled  in dependency org.a:project-b:0, but not for the dependency org.a:project-b:0 itself.

Why it happens:
When we select from the DB pairs (dependency, library), we only ensure that the digest of the dependency and of the bundled library are different. We then create instances of VulnerableDependency for the pair dependency and bug associated to the bundled library. As the GAV of the dependency itself is usually part of the set of bundledLibraries, the bug affecting the dependency itself are also found when processing bundledLibraries, however they do not appear in the final list as such entries already exists in the List of VulnerableDependency (see implementation of method compareTo). This means that the order in which the list is populated is critical.
The problem observed occurs in the case of GAVs associated to multiple libraries (digests) including the jar with dependencies. In such case the query returns (among others) the pair dependency and library where the library digest is the one of the jar with dependencies. This results into pairs dependency, bugs that do not really affect the application.

Solution:
Restrict the where condition of the query to only returns pairs dependency, library, not only for libraries with different digests but also different GAVs.

added condition on different gavs to select bundled libs