### PR TITLE
Fix (again) missing parent dependency

### DIFF
--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/AffectedLibraryRepositoryImpl.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/AffectedLibraryRepositoryImpl.java
@@ -270,6 +270,7 @@ public class AffectedLibraryRepositoryImpl implements AffectedLibraryRepositoryC
 		}
 	}
 	
+	/** {@inheritDoc} */
 	public List<AffectedLibrary> getAffectedLibraries(Bug _bug, AffectedVersionSource _source, Boolean _onlyWellknown){
 		if(_source==null && !_onlyWellknown)
 			return this.affLibRepository.findByBug(_bug);

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/ApplicationRepositoryImpl.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/ApplicationRepositoryImpl.java
@@ -124,6 +124,7 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
 
 	
 	/** {@inheritDoc} */
+	@Transactional
 	public Application customSave(Application _app) {
 		final StopWatch sw = new StopWatch("Save app " + _app).start();
 


### PR DESCRIPTION
The Internal Server Error "Missing Dependency with id XYZ" is still occurring as PR #355 didn't solve the problem entirely (it mainly prevents the multiplication of dependencies).

The error occurs when several scans of the same application are run in parallel. It can be reproduced triggering several time the HTTP requests corresponding to the goals CLEAN and APP. In particular, it consistently occur when running 7 times the pair of calls to clean (POST) and save the app (PUT).
The "missing dependency" issue occurs at the end of the parallel calls, whereas during their execution we get different exceptions: constraint violation on app_constricts_pk (when saving the same application in parallel) and optimisticLocking exception (when saving entities that were updated or deleted in parallel).

Solution:
We add the transactional annotation to the customSave method of ApplicationRepositoryImpl.class so that changes are rolledback if something goes wrong.