### PR TITLE
Removed API section from LICENSE.txt, and added reference to 3rd party component p-queue

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -202,11 +202,6 @@
    limitations under the License.
 
 ------------------------------------------------------------------------------
-APIs
-
-This project may include APIs to SAP or third party products or services. The use of these APIs, products and services may be subject to additional agreements. In no event shall the application of the Apache Software License, v.2 to this project grant any rights in or to these APIs, products or services that would alter, expand, be inconsistent with, or supersede any terms of these additional agreements. API means application programming interfaces, as well as their respective specifications and implementing code that allows other software products to communicate with or call on SAP or third party products or services (for example, SAP Enterprise Services, BAPIs, Idocs, RFCs and ABAP calls or other user exits) and may be made available through SAP or third party products, SDKs, documentation or other media. 
-
-------------------------------------------------------------------------------
 SUBCOMPONENTS
 
 This project includes the following subcomponents that are subject to separate license terms. 
@@ -223,6 +218,12 @@ Component: Dependency Finder
 Licensor: Jean Tessier
 Website: https://github.com/jeantessier/dependency-finder
 License: BSD-like (https://github.com/jeantessier/dependency-finder/blob/master/license.txt, a copy is included below)
+Additional Notices: N.a.
+
+Component: p-queue
+Licensor: Sindre Sorhus
+Website: https://github.com/sindresorhus/p-queue
+License: MIT
 Additional Notices: N.a.
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Following the request from Eclipse's legal time, one paragraph from `LICENSE.txt` has been removed. It referred to the potential use of SAP APIs, and has been added by default when going open source in 2018. However, given that no SAP APIs are used, and since the project moved to the Eclipse Foundation, this paragraph is no longer necessary. Moreover, `LICENSE.txt` has also been updated to reflect the use of the 3rd party component p-queue.

#### `TODO`s

- [ ] Tests
- [ ] Documentation