### PR TITLE
Transactional retrieval of vulnerable dependencies

### DIFF
--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/ApplicationRepositoryImpl.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/ApplicationRepositoryImpl.java
@@ -503,6 +503,7 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
 	 * Finds all @{VulnerableDependency}s for a given {@link Space} and {@link Application}.
 	 */
 	@Override
+	@Transactional(readOnly=true)
 	public TreeSet<VulnerableDependency> findAppVulnerableDependencies(Application _app, boolean _add_excemption_info, boolean _log) {
 		final StopWatch sw = new StopWatch("Query vulnerable dependencies for application " + _app);
 		if(_log)


### PR DESCRIPTION
Added transactional annotation to the retrieval of vulnerable dependencies to avoid ObjectNotFoundException when retrieving objects from the db by Id. The exception would occur in the case of parallel executions where one scan retrieves vulnerable dependencies and another saves application dependencies (altering the ids).

Note.
The observed exception occurred in line 532 of ApplicationRepositoryImpl.java:
