### PR TITLE
Specifying versions for mkdocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
-mkdocs
-pymdown-extensions
-mkdocs-material
-markdown-include
+mkdocs==1.0.4
+pymdown-extensions==6.1
+mkdocs-material==4.4.3
+markdown-include==0.5.1
 GitPython
 fire
 pathlib


### PR DESCRIPTION
Signed-off-by: Sumeet Patil <sumeet.patil@sap.com>

Specifying versions for mkdocs

- With default pip install all the new versions are installed
- New versions introduce lot inconsistencies and errors in the github pages
- New release changes - https://squidfunk.github.io/mkdocs-material/releases/5/
- This is a quick fix. But the permanent fix will be to adapt to version 5



#### `TODO`s

- [x] Tests
- [ ] Documentation