### PR TITLE
Exclude PACK and CLAS from traced flag

### DIFF
--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/TracesRepository.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/TracesRepository.java
@@ -155,11 +155,13 @@ public interface TracesRepository extends CrudRepository<Trace, Long>, TracesRep
 			+ "   Trace t,"
 			+ "   Bug b"
 			+ "   JOIN b.constructChanges cc"
+			+ "   JOIN cc.constructId c"
 			+ " WHERE"
 			+ "   cc.constructId = t.constructId"
 			+ "   AND t.lib = :lib"
 			+ "   AND t.app = :app"
-			+ "   AND b.id = :bug_id")
+			+ "   AND b.id = :bug_id"
+			+ "	  AND NOT (c.type='PACK' OR c.type='CLAS')")
 	List<Trace> findVulnerableTracesOfLibraries(@Param("app") Application app, @Param("lib") Library lib, @Param("bug_id") Long bug_id);
 
 


### PR DESCRIPTION
Problem: Vulnerability shown as traced in the overview (red paw) but none of the construct are shown as traced in the vulnerbility details.

Analysis:
Since version 3.0.18, the client also traces (and uploads) constructs of type PACK and CLAS. However those must not be used to compute the traced flag at the level of the vulnerability (resulting in the red paw in the vulnerability overview table). 