### PR TITLE
Protect PUT and POST endpoints of the BugController

### DIFF
--- a/frontend-bugs/src/main/webapp/model/Config.js
+++ b/frontend-bugs/src/main/webapp/model/Config.js
@@ -18,12 +18,14 @@
  * Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved.
  */
 jQuery.sap.declare("model.Config");
+jQuery.sap.require("jquery.sap.storage");
 
 model.Config = {
-	mock : true,
-	host : "/backend",
-    ciaHost : "/cia",
-    lang : "",
+		cookie : {  host : "/backend",
+			ciaHost : "/cia",
+			token : ""
+		},
+	lang : "",
 	user: "",
 	pwd: "",
 	user: "",
@@ -31,12 +33,45 @@ model.Config = {
 	skipEmpty : true
 };
 
-model.Config.setHost = function(_host){
-	model.Config.host=_host;
+var oStore = jQuery.sap.storage(jQuery.sap.storage.Type.local);
+
+//populates the settings with the data read from the cookie
+//called in the init of Master.controller
+model.Config.setModel = function(_m){
+	if(_m) {
+		if (typeof _m === 'string') {
+			model.Config.cookie = JSON.parse(_m)
+		} else {
+			model.Config.cookie = _m
+		}
+	}
+}
+
+model.Config.setHost = function(_host) {
+	model.Config.cookie.host=_host;
+	oStore.put("vulas-frontend-settings", model.Config.cookie)
+}
+
+model.Config.getHost = function() {
+	return model.Config.cookie.host;
 }
 
 model.Config.setCiaHost = function(_host){
-	model.Config.ciaHost=_host;
+	model.Config.cookie.ciaHost=_host;
+	oStore.put("vulas-frontend-settings", model.Config.cookie)
+}
+
+model.Config.getCiaHost = function() {
+	return model.Config.cookie.ciaHost;
+}
+
+model.Config.setToken = function(_token){
+	model.Config.cookie.token =_token;
+	oStore.put("vulas-frontend-settings", model.Config.cookie)
+}
+
+model.Config.getToken = function() {
+	return model.Config.cookie.token;
 }
 
 model.Config.setLang = function(_lang){
@@ -47,9 +82,6 @@ model.Config.getLang = function(){
 	return model.Config.lang;
 }
 
-model.Config.getHost = function(){
-	return model.Config.host;
-}
 model.Config.setUser = function(_usr){
 	model.Config.user=_usr;
 }
@@ -79,152 +111,78 @@ model.Config.loadDataSync = function(oModel,sUrl, method) {
 }
 
 model.Config.getCvesServiceUrl = function(cve) {
-	//return model.Config.host+"/vulasfrontend/xs/assessment/getArchives.xsjs";
-	return model.Config.host+"/cves/"+ cve;
+	return model.Config.getHost()+"/cves/"+ cve;
 }
+
 /**
  * get the bugs list
  */
 model.Config.getBugsAsUrl = function(){
-    return model.Config.host+"/bugs?lang="+ model.Config.lang;
+    return model.Config.getHost()+"/bugs?lang="+ model.Config.lang;
 }
 
 model.Config.getBugsAsBaseUrl = function(){
-    return model.Config.host+"/bugs";
+    return model.Config.getHost()+"/bugs";
 }
 
-
 /**
- * Get detail for the selected bugid
+ * Get details for the selected bugid
  */
 model.Config.getBugDetailsAsUrl = function(bugId, source){
     return model.Config.getBugsAsBaseUrl()+"/"+bugId;
 }
 
+/**
+ * Get affectedLibrary for selected bugid and GAV
+ */
 model.Config.getBugDetailsAffVersion = function(bugId, source,g,a,v){
     return model.Config.getBugsAsBaseUrl()+"/"+bugId+"/affectedLibIds/"+g+"/"+a+"/"+v+"/?source="+source;
 }
 
+/**
+ * Get all affectedLibraries for selected bugid
+ */
 model.Config.getBugAllAffVersion = function(bugId){
     return model.Config.getBugsAsBaseUrl()+"/"+bugId+"/affectedLibIds";
 }
 
-
+/**
+ * Get all libraries for selected bugid
+ */
 model.Config.getBugDetailsLibrariesAsUrl = function(bugId){
     return model.Config.getBugsAsBaseUrl()+"/"+bugId+"/libraries";
 }
 
-/**
- * the service url for applications
- */
-model.Config.getMyAppsServiceUrl = function() {
-	//return model.Config.host+"/vulasfrontend/xs/assessment/getMyApplications.xsjs";
-	if(model.Config.skipEmpty)
-		return model.Config.host+"/apps?skipEmpty=true";
-	else
-		return model.Config.host+"/apps";
-};
-
-/**
- * the service url for archives
- */
-model.Config.getArchivesServiceUrl = function(g,a,v) {
-	//return model.Config.host+"/vulasfrontend/xs/assessment/getArchives.xsjs";
-	return model.Config.host+"/apps/"+ g + "/" + a + "/" + v +"/deps";
-};
-
-/**
- * the service url for goal executions
- */
-model.Config.getGoalExecutionsServiceUrl = function(g,a,v) {
-	//return model.Config.host+"/vulasfrontend/xs/assessment/getGoalExecutions.xsjs";
-	return model.Config.host+"/apps/"+ g + "/" + a + "/" + v +"/goals";
-};
-
-/**
- * the service url for goal execution details
- */
-model.Config.getGoalExecutionDetailsServiceUrl = function() {
-	return model.Config.host+"/vulasfrontend/xs/assessment/getGoalExecutionDetails.xsjs";
-};
-
-/**
- * the service url for user info
- */
-/*model.Config.getUserServiceUrl = function() {
-	return model.Config.host+"/vulasfrontend/xs/assessment/getUserInfo.xsjs";
-};*/
-
-/**
- * the service url for archive properties
- */
-model.Config.getArchivePropertiesServiceUrl = function(g,a,v,sha1) {
-	//return model.Config.host+"/vulasfrontend/xs/assessment/getArchiveDetails.xsjs";
-	//console.log(model.Config.host+"/apps/"+ g + "/" + a + "/" + v +"/deps/" + sha1);
-	return model.Config.host+"/apps/"+ g + "/" + a + "/" + v +"/deps/" + sha1;
-};
-
-/**
- * the service url for used vulnerabilities
- */
-model.Config.getUsedVulnerabilitiesServiceUrl = function(g,a,v) {
-	//return model.Config.host+"/vulasfrontend/xs/assessment/getUsedVulnerabilities.xsjs";
-	return model.Config.host+"/apps/"+ g + "/" + a + "/" + v +"/vulndeps";
-};
-
-/**
- * the service url for vulnerability details
- */
-model.Config.getVulnerabilityDetailsServiceUrl = function(g,a,v,sha1,bug) {
-	//return model.Config.host+"/vulasfrontend/xs/assessment/getVulnerabilityDetails.xsjs";
-//	console.log(model.Config.host+"/apps/"+ g + "/" + a + "/" + v +"/vulndeps/"+sha1+"/bugs/"+bug);
-	return model.Config.host+"/apps/"+ g + "/" + a + "/" + v +"/vulndeps/"+sha1+"/bugs/"+bug;
-};
-
-model.Config.getReachabilityGraphServiceUrl = function(g,a,v,sha1,bug,cid) {
-	//return model.Config.host+"/vulasfrontend/xs/assessment/getReachabilityGraph.xsjs";
-	return model.Config.host+"/apps/"+ g + "/" + a + "/" + v +"/deps/"+sha1+"/paths/"+bug+"/"+cid;
-};
-
-/**
- * the service url for packages including test coverage
- */
-model.Config.getPackagesWithTestCoverageServiceUrl = function(g,a,v) {
-	//return model.Config.host+"/vulasfrontend/xs/assessment/getPackagesWithTestCoverage.xsjs";
-	return model.Config.host+"/apps/"+ g + "/" + a + "/" + v;
-};
-
-/**
- * the service url for CVE details
- */
-model.Config.getCveDetailsUrl = function() {
-	return model.Config.host+"/vulasfrontend/xs/assessment/getCveDetails.xsjs";
-};
-
 model.Config.getDiff = function() {
-	return model.Config.ciaHost+"/constructs/diff";
+	return model.Config.getCiaHost()+"/constructs/diff";
 };
 
+/**
+ * Get affected construct changes for selected bugid and library digest
+ */
 model.Config.getAffectedConstructsSha1Bugid = function(sha1,bugid){
-    //return model.Config.host+"/libs/"+sha1+"/bugs/"+bugid+"/constructIds";
-    return model.Config.host+"/libs/"+sha1+"/bugs/"+bugid+"/affConstructChanges";
+    return model.Config.getHost()+"/libs/"+sha1+"/bugs/"+bugid+"/affConstructChanges";
 };
 
-
-model.Config.getCiaHostUrl = function() {
-    return model.Config.ciaHost;
-};
-
+/**
+ * Get all artifacts for a given GA
+ */
 model.Config.getAffectedMavenArtifacts = function(ga) {
-  return model.Config.getCiaHostUrl() + "/artifacts/" + ga;
+  return model.Config.getCiaHost() + "/artifacts/" + ga;
 };
 
+/**
+ * Get library for selected digest
+ */
 model.Config.getLibraryDetailsUrl = function(sha1){
-  return model.Config.host+"/libs/"+sha1;  
+  return model.Config.getHost()+"/libs/"+sha1;  
 };
 
+/**
+ * Get all applications with dependency on selected digest
+ */
 model.Config.getLibraryApplicationsUrl = function(sha1){
-  return model.Config.host+"/libs/"+sha1+"/apps";  
+  return model.Config.getHost()+"/libs/"+sha1+"/apps";  
 };
 
 model.Config.getMavenId = function (affectedVersion){
@@ -248,7 +206,7 @@ model.Config.getMavenId = function (affectedVersion){
 
 
 model.Config.uploadManualAssessment = function(data, pbugid ){
-    var baseurl = model.Config.host + "/bugs/";
+    var baseurl = model.Config.getHost() + "/bugs/";
     var trail = "/affectedLibIds?source=MANUAL";
     var fullUrl = baseurl + pbugid + trail;
     var elementArray = [];
@@ -290,7 +248,7 @@ model.Config.uploadManualAssessment = function(data, pbugid ){
     $.ajax({
         type: "PUT",
         url : fullUrl,
-        headers : {'content-type': "application/json",'cache-control': "no-cache" },
+        headers : {'content-type': "application/json",'cache-control': "no-cache", 'X-Vulas-Client-Token' : model.Config.getToken() },
         data : JSON.stringify(elementArray),
         success : function(msg){
             sap.ui.commons.MessageBox.alert("Data correctly updated via PUT");
@@ -303,7 +261,7 @@ model.Config.uploadManualAssessment = function(data, pbugid ){
                   $.ajax({
                       type: "POST",
                       url : fullUrl,
-                      headers : {'content-type': "application/json",'cache-control': "no-cache" },
+                      headers : {'content-type': "application/json",'cache-control': "no-cache",'X-Vulas-Client-Token' : model.Config.getToken() },
                       data : JSON.stringify(elementArray),
                       success : function(msg){
                           sap.ui.commons.MessageBox.alert("Data correctly updated via POST");
@@ -374,7 +332,7 @@ model.Config.uploadCVEDescription = function(newjson, url){
     $.ajax({
         type: "PUT",
         url : url,
-        headers : {'content-type': "application/json",'cache-control': "no-cache" },
+        headers : {'content-type': "application/json",'cache-control': "no-cache",'X-Vulas-Client-Token' : model.Config.getToken() },
         data : JSON.stringify(newjson),
         success : function(msg){
             sap.ui.commons.MessageBox.alert("Data correctly updated");
@@ -402,20 +360,4 @@ model.Config.uploadCVEDescription = function(newjson, url){
     return toLookup;
 };*/
 
-/**
- * 
- */
-(function() {
 
-	// The "reponder" URL parameter defines if the app shall run with mock data
-	var responderOn = jQuery.sap.getUriParameters().get("responderOn");
-
-	// set the flag for later usage
-	model.Config.isMock = ("true" === responderOn)
-			|| !model.Config.getMyAppsServiceUrl()
-			|| !model.Config.getArchivesServiceUrl()
-			|| !model.Config.getUsedVulnerabilitiesServiceUrl()
-			|| !model.Config.getPackagesWithTestCoverageServiceUrl()
-			|| !model.Config.getArchivePropertiesServiceUrl()
-			|| !model.Config.getVulnerabilityDetailsServiceUrl()
-})();

--- a/frontend-bugs/src/main/webapp/view/Component.controller.js
+++ b/frontend-bugs/src/main/webapp/view/Component.controller.js
@@ -278,7 +278,7 @@ sap.ui.controller(
 											var aNaUrl = model.Config.getAffectedMavenArtifacts(gas[ga] );
 											$.ajax({  type: "GET",
 											        url: aNaUrl,
-											        headers : {'content-type': "application/json",'cache-control': "no-cache" ,'X-Vulas-Version':model.Version.version,'X-Vulas-Component':'appfrontend'},
+											        headers : {'content-type': "application/json",'cache-control': "no-cache" ,'X-Vulas-Version':model.Version.version,'X-Vulas-Component':'bugfrontend'},
 											        success: function(response) {
 												allversions.setData(response);
 												var oAffectedMavenVersions = allversions.getObject("/");

--- a/frontend-bugs/src/main/webapp/view/Master.controller.js
+++ b/frontend-bugs/src/main/webapp/view/Master.controller.js
@@ -22,6 +22,9 @@ sap.ui.controller("view.Master",{
 onInit : function() {
 	jQuery.sap.require("sap.m.MessageBox");
 	this.router = sap.ui.core.UIComponent.getRouterFor(this);
+	
+	var oStore = jQuery.sap.storage(jQuery.sap.storage.Type.local);
+	model.Config.setModel(oStore.get("vulas-frontend-settings"));
 
 	// move the search bar below the pullToRefresh on touch
 	// devices
@@ -166,16 +169,12 @@ clone : function(obj) {
 														var mLayout = sap.ui
 																.getCore()
 																.byId("Shell");
-														// mLayout is the id of
-														// main layout. Change
-														// it accordingly
+														// mLayout is the id of main layout. Change it accordingly
 
 														mLayout.destroy();
 														sap.ui.getCore()
 																.applyChanges();
-														// jQuery(document.body).html("<span>Logged
-														// out
-														// successfully.</span>");
+														// jQuery(document.body).html("<span>Logged out successfully.</span>");
 														window.location
 																.reload();
 
@@ -206,27 +205,10 @@ clone : function(obj) {
 																		model.Config.setCiaHost(sap.ui.getCore().byId('idCiaURL').getValue());
 																	if (sap.ui.getCore().byId('idLang').getValue() != null )
 																		model.Config.setLang(sap.ui.getCore().byId('idLang').getValue());
-																	// if(sap.ui.getCore().byId('idUsr').getValue()
-																	// !=null &&
-																	// sap.ui.getCore().byId('idUsr').getValue()
-																	// !="")
-																	// model.Config.setUser(sap.ui.getCore().byId('idUsr').getValue());
-																	// if(sap.ui.getCore().byId('idPwd').getValue()
-																	// !=null &&
-																	// sap.ui.getCore().byId('idPwd').getValue()
-																	// !="")
-																	// model.Config.setPwd(sap.ui.getCore().byId('idPwd').getValue());
-																	/*
-																	 * if(sap.ui.getCore().byId('idSkipEmpty').getState()
-																	 * !=model.Config.getSkipEmpty())
-																	 * model.Config.setSkipEmpty(sap.ui.getCore().byId('idSkipEmpty').getState());
-																	 */
+																	if (sap.ui.getCore().byId('idToken').getValue() != null && sap.ui.getCore().byId('idToken').getValue() != "")
+																		model.Config.setToken(sap.ui.getCore().byId('idToken').getValue());
 																	// this.oPopoverSettings.close();
-																	sap.ui
-																			.getCore()
-																			.byId(
-																					'settings_popover')
-																			.close();
+																	sap.ui.getCore().byId('settings_popover').close();
 																}
 															}) ],
 													contentLeft : [ new sap.m.Button(
@@ -235,11 +217,7 @@ clone : function(obj) {
 																icon : "sap-icon://close",
 																press : function() {
 																	// this.oPopoverSettings.close();
-																	sap.ui
-																			.getCore()
-																			.byId(
-																					'settings_popover')
-																			.close();
+																	sap.ui.getCore().byId('settings_popover').close();
 																}
 															}) ]
 												}),
@@ -249,20 +227,9 @@ clone : function(obj) {
 															label : "Back-end URL",
 															content : new sap.m.Input(
 																	{
-
 																		id : "idHostURL",
 																		type : sap.m.InputType.Text,
-																		// placeholder:
-																		// 'Enter
-																		// host
-																		// address
-																		// (default:
-																		// 127.0.0.1)
-																		// ...',
-																		// width:
-																		// "100%",
-																		value : model.Config
-																				.getHost()
+																		value : model.Config.getHost()
 																	})
 														}),
 												new sap.m.InputListItem(
@@ -270,23 +237,12 @@ clone : function(obj) {
 															label : "Cia URL",
 															content : new sap.m.Input(
 																	{
-
 																		id : "idCiaURL",
 																		type : sap.m.InputType.Text,
-																		// placeholder:
-																		// 'Enter
-																		// host
-																		// address
-																		// (default:
-																		// 127.0.0.1)
-																		// ...',
-																		// width:
-																		// "100%",
-																		value : model.Config
-																				.getCiaHostUrl()
+																		value : model.Config.getCiaHost()
 																	})
 														}),
-														new sap.m.InputListItem(
+												new sap.m.InputListItem(
 																{
 																	label : "Lang",
 																	content : new sap.m.ComboBox("idLang",
@@ -297,29 +253,19 @@ clone : function(obj) {
 														            		new sap.ui.core.ListItem({text:'PY'}),
 														            		new sap.ui.core.ListItem({text:''})]
 														            		})
-																})
-										/*
-										 * , new sap.m.InputListItem({
-										 * label:"Username", content:new
-										 * sap.m.Input({ id: "idUsr", type:
-										 * sap.m.InputType.Text, // placeholder:
-										 * 'biroot', // placeholder: 'Enter
-										 * user/login (default: smash) ...', //
-										 * width: "100%", value:
-										 * model.Config.getUser() }) }), new
-										 * sap.m.InputListItem({ label:"Pwd",
-										 * content: new sap.m.Input({ id :
-										 * "idPwd", type:
-										 * sap.m.InputType.Password, //
-										 * placeholder: 'Enter password ...',
-										 * type:"Password", // width: "100%",
-										 * value: "" }) }), new
-										 * sap.m.InputListItem({ label:"Skip
-										 * Empty Apps", content: new
-										 * sap.m.Switch({ id : "idSkipEmpty",
-										 * state: model.Config.getSkipEmpty() //
-										 * width: "100%", }) })
-										 */]
+																}),
+												new sap.m.InputListItem(
+														{
+															label : "Token",
+															content : new sap.m.Input(
+																	{
+
+																		id : "idToken",
+																		type : sap.m.InputType.Text,
+																		value : model.Config.getToken()
+																	})
+														})
+										]
 									});
 							this.getView().addDependent(this.oPopoverSettings);
 						}

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/BasicHttpRequest.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/BasicHttpRequest.java
@@ -19,14 +19,12 @@
  */
 package com.sap.psr.vulas.backend.requests;
 
-import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.ObjectInputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
@@ -40,13 +38,10 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
-import javax.validation.constraints.NotNull;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.sap.psr.vulas.backend.BackendConnectionException;
-import com.sap.psr.vulas.backend.BackendConnector;
 import com.sap.psr.vulas.backend.HttpMethod;
 import com.sap.psr.vulas.backend.HttpResponse;
 import com.sap.psr.vulas.core.util.CoreConfiguration;
@@ -57,7 +52,6 @@ import com.sap.psr.vulas.shared.json.JsonSyntaxException;
 import com.sap.psr.vulas.shared.util.Constants;
 import com.sap.psr.vulas.shared.util.FileUtil;
 import com.sap.psr.vulas.shared.util.StringUtil;
-import com.sap.psr.vulas.shared.util.VulasConfiguration;
 
 /**
  * <p>BasicHttpRequest class.</p>
@@ -334,6 +328,14 @@ public class BasicHttpRequest extends AbstractHttpRequest {
 				// Include version and component as request header
 				connection.setRequestProperty(Constants.HTTP_VERSION_HEADER, CoreConfiguration.getVulasRelease());
 				connection.setRequestProperty(Constants.HTTP_COMPONENT_HEADER, Constants.VulasComponent.client.toString());
+				
+				// Include additional headers from configuration (if any)
+				final Map<String, String> add_headers = this.getVulasConfiguration().getServiceHeaders(this.service);
+				if(add_headers!=null && add_headers.size()>0) {
+					for(String key: add_headers.keySet()) {
+						connection.setRequestProperty(key, add_headers.get(key));
+					}
+				}
 				
 				// Only if put something in the body
 				if(this.hasPayload()) {

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/VulasConfiguration.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/VulasConfiguration.java
@@ -790,7 +790,7 @@ public class VulasConfiguration {
 	 * Returns key-value pairs to be added as HTTP headers in calls to the given {@link Service}.
 	 * 
 	 * All configuration settings of the following form will be included in the map:
-	 * vulas.shared.&lt;service&gt;.&lt;header&gt; = &lt;value&gt;
+	 * vulas.shared.&lt;service&gt;.header.&lt;key&gt; = &lt;value&gt;
 	 *
 	 * Note: Does not work for comma-separated enumerations
 	 * 

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/VulasConfiguration.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/VulasConfiguration.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLDecoder;
 import java.nio.file.Files;
@@ -785,6 +784,30 @@ public class VulasConfiguration {
 				value = value.substring(0, value.length()-1);
 		}
 		return value;
+	}
+
+	/**
+	 * Returns key-value pairs to be added as HTTP headers in calls to the given {@link Service}.
+	 * 
+	 * All configuration settings of the following form will be included in the map:
+	 * vulas.shared.&lt;service&gt;.&lt;header&gt; = &lt;value&gt;
+	 *
+	 * Note: Does not work for comma-separated enumerations
+	 * 
+	 * @param _service a {@link com.sap.psr.vulas.shared.connectivity.Service} object.
+	 * @return a boolean.
+	 */
+	public Map<String, String> getServiceHeaders(Service _service) {
+		final String key_prefix = "vulas.shared." + _service.toString().toLowerCase() + ".header";
+		final Configuration subset = getConfiguration().subset(key_prefix);
+		final Iterator<String> iter = subset.getKeys();
+		final Map<String, String> headers = new HashMap<String, String>();
+		while(iter.hasNext()) {
+			final String key = iter.next();
+			final String val = subset.getProperty(key).toString();
+			headers.put(key, val);
+		}
+		return headers;
 	}
 
 	/**

--- a/shared/src/test/java/com/sap/psr/vulas/shared/util/VulasConfigurationTest.java
+++ b/shared/src/test/java/com/sap/psr/vulas/shared/util/VulasConfigurationTest.java
@@ -217,10 +217,12 @@ public class VulasConfigurationTest {
 		VulasConfiguration c1 = new VulasConfiguration();
 		c1.setProperty("vulas.shared.backend.header.foo", "bar");
 		c1.setProperty("vulas.shared.backend.header.baz", 1);
+		c1.setProperty("vulas.shared.backend.header.X-Vulas-Client-Token", "AJDEY@HEX@EWX@XEH@I*QA");
 		//c1.setProperty("vulas.shared.backend.header.test", "123, 456");
 		final Map<String, String> headers = c1.getServiceHeaders(Service.BACKEND);
 		assertEquals("bar", headers.get("foo"));
 		assertEquals("1", headers.get("baz"));
+		assertEquals("AJDEY@HEX@EWX@XEH@I*QA", headers.get("X-Vulas-Client-Token"));
 		//assertEquals("123, 456", headers.get("test"));
 	}
 }

--- a/shared/src/test/java/com/sap/psr/vulas/shared/util/VulasConfigurationTest.java
+++ b/shared/src/test/java/com/sap/psr/vulas/shared/util/VulasConfigurationTest.java
@@ -210,4 +210,17 @@ public class VulasConfigurationTest {
 		c1.setProperty(VulasConfiguration.getServiceUrlKey(Service.BACKEND), url);
 		assertEquals(url, c1.getServiceUrl(Service.BACKEND));
 	}
+	
+	@Test
+	public void testGetServiceHeaders() {
+		final String url = "http://localhost:8000/backend";
+		VulasConfiguration c1 = new VulasConfiguration();
+		c1.setProperty("vulas.shared.backend.header.foo", "bar");
+		c1.setProperty("vulas.shared.backend.header.baz", 1);
+		//c1.setProperty("vulas.shared.backend.header.test", "123, 456");
+		final Map<String, String> headers = c1.getServiceHeaders(Service.BACKEND);
+		assertEquals("bar", headers.get("foo"));
+		assertEquals("1", headers.get("baz"));
+		//assertEquals("123, 456", headers.get("test"));
+	}
 }


### PR DESCRIPTION
POST and PUT calls of the BugController shall be protected through a dedicated, configurable token.

This token has to be added as HTTP header by all Java clients (kb-importer, patch-analyzer, patch-lib-analyzer) and by the bug frontend (frontend-bugs). The Java clients just require a corresponding configuration parameter (`vulas.shared.backend.header.<key>`) in order to include the HTTP header.

The HAProxy configuration has to be adjusted to check the configurable token for all HTTP PUT and POST requests to `.../backend/bugs/...`.

#### `TODO`s

- [ ] Tests
- [ ] Documentation