### PR TITLE
Check if Library Id (GAV) is well known

### DIFF
--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/model/Library.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/model/Library.java
@@ -481,7 +481,7 @@ public class Library implements Serializable {
 	/**
 	 * Verifies that the digest is well known by either one of the existing
 	 * verifiers (e.g. maven central, pypi). If the digests is well known and the
-	 * provided libraryId is not among those returned by the verifiers, it sets the
+	 * provided libraryId is NOT among those returned by the verifiers, it sets the
 	 * LibraryId with the (first) value returned by the verifier.
 	 * 
 	 */

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/model/Library.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/model/Library.java
@@ -407,9 +407,6 @@ public class Library implements Serializable {
 		if(this.getModifiedAt()==null) {
 			this.setModifiedAt(Calendar.getInstance());
 		}
-//		if(this.getWellknownDigest()==null) {
-//			this.verifyDigest();
-//		}
 		// If uploaded by old client (<3.0.0), the digest also must be set
 		if(this.sha1!=null && (this.digest==null || this.digestAlgorithm==null)) {
 			this.digest = this.sha1;

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryRepositoryImpl.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryRepositoryImpl.java
@@ -86,17 +86,7 @@ public class LibraryRepositoryImpl implements LibraryRepositoryCustom {
 			_lib.setId(managed_lib.getId());
 			_lib.setCreatedAt(managed_lib.getCreatedAt());
 			_lib.setModifiedAt(Calendar.getInstance());
-			
-//			//	Re-create wellknownDigest if it is null in our current db (this part should be removed once it is created for all)
-//			if(managed_lib.getWellknownDigest()==null || (managed_lib.getDigestTimestamp()==null && managed_lib.getWellknownDigest())) {
-//				_lib.verifyDigest();
-//			}
-//			else {
-//				_lib.setWellknownDigest(managed_lib.getWellknownDigest());
-//				_lib.setDigestVerificationUrl(managed_lib.getDigestVerificationUrl());
-//				_lib.setDigestTimestamp(managed_lib.getDigestTimestamp());
-//			}
-			
+						
 			//keep the existing lib GAV if the newly posted/put doesn't have one
 			if(_lib.getLibraryId()==null){
 				// Recreate libId if null (to be removed once we ensure we added to the existing libs)

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryRepositoryImpl.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryRepositoryImpl.java
@@ -88,15 +88,15 @@ public class LibraryRepositoryImpl implements LibraryRepositoryCustom {
 			_lib.setCreatedAt(managed_lib.getCreatedAt());
 			_lib.setModifiedAt(Calendar.getInstance());
 			
-			//	Re-create wellknownDigest if it is null in our current db (this part should be removed once it is created for all)
-			if(managed_lib.getWellknownDigest()==null || (managed_lib.getDigestTimestamp()==null && managed_lib.getWellknownDigest())) {
-				_lib.verifyDigest();
-			}
-			else {
-				_lib.setWellknownDigest(managed_lib.getWellknownDigest());
-				_lib.setDigestVerificationUrl(managed_lib.getDigestVerificationUrl());
-				_lib.setDigestTimestamp(managed_lib.getDigestTimestamp());
-			}
+//			//	Re-create wellknownDigest if it is null in our current db (this part should be removed once it is created for all)
+//			if(managed_lib.getWellknownDigest()==null || (managed_lib.getDigestTimestamp()==null && managed_lib.getWellknownDigest())) {
+//				_lib.verifyDigest();
+//			}
+//			else {
+//				_lib.setWellknownDigest(managed_lib.getWellknownDigest());
+//				_lib.setDigestVerificationUrl(managed_lib.getDigestVerificationUrl());
+//				_lib.setDigestTimestamp(managed_lib.getDigestTimestamp());
+//			}
 			
 			//keep the existing lib GAV if the newly posted/put doesn't have one
 			if(_lib.getLibraryId()==null){
@@ -123,6 +123,11 @@ public class LibraryRepositoryImpl implements LibraryRepositoryCustom {
 		sw.lap("Updated refs to nested properties");
 		
 		_lib.setBundledLibraryIds(refUpdater.saveNestedBundledLibraryIds(_lib.getBundledLibraryIds()));
+		
+		// we always verify the digest to make sure all fields are filled and check that
+		// libraryId provided by the client is known (replaced with known one otherwise)
+		// Note that this replaces digestVerificationUrl, digestTimestamp and WellknownDigest
+		_lib.verifyDigest();
 		
 		_lib = this.saveNestedLibraryId(_lib);
 		
@@ -169,6 +174,7 @@ public class LibraryRepositoryImpl implements LibraryRepositoryCustom {
 	/** {@inheritDoc} */
 	public Library saveIncomplete(Library _lib) throws PersistenceException {
 		Library incomplete = new Library(_lib.getDigest());
+		incomplete.setDigestAlgorithm(_lib.getDigestAlgorithm());
 		if (_lib.getLibraryId()!=null){
 			LibraryRepositoryImpl.log.debug("Setting library Id ["+_lib.getLibraryId().toString()+"] of incomplete library [" +_lib.getDigest()+ "]");
 			incomplete.setLibraryId(_lib.getLibraryId());

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryRepositoryImpl.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryRepositoryImpl.java
@@ -21,7 +21,6 @@ package com.sap.psr.vulas.backend.repo;
 
 import java.nio.file.Path;
 import java.util.Calendar;
-import java.util.Collection;
 
 import javax.persistence.EntityNotFoundException;
 import javax.persistence.PersistenceException;

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/DigestVerifier.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/DigestVerifier.java
@@ -19,9 +19,11 @@
  */
 package com.sap.psr.vulas.backend.util;
 
+import java.util.List;
 import java.util.Set;
 
 import com.sap.psr.vulas.backend.model.Library;
+import com.sap.psr.vulas.backend.model.LibraryId;
 import com.sap.psr.vulas.shared.enums.DigestAlgorithm;
 import com.sap.psr.vulas.shared.enums.ProgrammingLanguage;
 
@@ -64,11 +66,11 @@ public interface DigestVerifier {
 
 	/**
 	 * Returns null if the verification did not succeed, e.g., due to connectivity issues.
-	 * Returns true or false depending on whether the digest is known to the respective package repo.
+	 * Returns the list of verified LibraryId if the digest is known to the respective package repo (an empty list otherwise).
 	 *
 	 * @throws com.sap.psr.vulas.backend.util.VerificationException if the verification URL could not be reached, the HTTP response was malformed or similar
 	 * @param _lib a {@link com.sap.psr.vulas.backend.model.Library} object.
 	 * @return a {@link java.lang.Boolean} object.
 	 */
-	public Boolean verify(Library _lib) throws VerificationException;
+	public List<LibraryId> verify(Library _lib) throws VerificationException;
 }

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/DigestVerifierEnumerator.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/DigestVerifierEnumerator.java
@@ -20,6 +20,7 @@
 package com.sap.psr.vulas.backend.util;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
 
@@ -27,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sap.psr.vulas.backend.model.Library;
+import com.sap.psr.vulas.backend.model.LibraryId;
 import com.sap.psr.vulas.shared.enums.DigestAlgorithm;
 import com.sap.psr.vulas.shared.enums.ProgrammingLanguage;
 import com.sap.psr.vulas.shared.util.CollectionUtil;
@@ -78,12 +80,12 @@ public class DigestVerifierEnumerator implements DigestVerifier {
 	 *
 	 * Loops over available implementations of {@link DigestVerifier} in order to verify the digest of a given {@link Library}.
 	 */
-	public Boolean verify(Library _lib) throws VerificationException {
+	public List<LibraryId> verify(Library _lib) throws VerificationException {
 		if(_lib==null || _lib.getDigest()==null)
 			throw new IllegalArgumentException("No library or digest provided: [" + _lib + "]");
 
-		// Will only have a true or false value if either one verifier returns true, or all returned false (thus, no exception happened)
-		Boolean verified = null;
+		// Will only have a list of LibraryIds or an empty list if either one verifier returns (thus, no exception happened)
+		List<LibraryId> verified = null;
 		int exception_count = 0;
 
 		// Perform the loop
@@ -96,7 +98,7 @@ public class DigestVerifierEnumerator implements DigestVerifier {
 					l.getSupportedDigestAlgorithms().contains(_lib.getDigestAlgorithm())) {
 				try {
 					verified = l.verify(_lib);
-					if(verified!=null && verified) {
+					if(verified!=null && verified.size()>0) {
 						this.url = l.getVerificationUrl();
 						this.timestamp = l.getReleaseTimestamp();
 						break;

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/MavenCentralVerifier.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/MavenCentralVerifier.java
@@ -121,15 +121,17 @@ public class MavenCentralVerifier implements DigestVerifier {
 						//MavenSearchResponse json_response = JsonPath.parse(mvnResponse).read("$.response", MavenSearchResponse.class);
 						
 						for(ResponseDoc d: json_response.getResponse().getSortedDocs()) {
-							verified_lids.add(new LibraryId(d.getG(),d.getA(),d.getV()));
-							//takes timestamp of the first artifact
-							if(this.timestamp==null) {
+							LibraryId current = new LibraryId(d.getG(),d.getA(),d.getV());
+							verified_lids.add(current);
+							// take timestamp of the artifact corresponding to the provided libraryId or the
+							// first one as that's the one we will use in case the provided one is not among
+							// the list of verified 
+							if(this.timestamp==null || current.equals(_lib.getLibraryId())) {
 								final long ms = d.getTimestamp();;
 								this.timestamp = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
 								this.timestamp.setTimeInMillis(ms);						
 							}
-						}
-							
+						}	
 					}
 				}
 			} finally {

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/MavenCentralVerifier.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/MavenCentralVerifier.java
@@ -116,10 +116,6 @@ public class MavenCentralVerifier implements DigestVerifier {
 					}
 					if(num_found>=1) {
 						
-						// TODO: read all returned libids (for now we only return the first one
-						//verified_lids.add(new LibraryId((String)JsonPath.read(mvnResponse, "$.response.docs[0].g"),(String)JsonPath.read(mvnResponse, "$.response.docs[0].a"),(String)JsonPath.read(mvnResponse, "$.response.docs[0].v")));
-						//MavenSearchResponse json_response = JsonPath.parse(mvnResponse).read("$.response", MavenSearchResponse.class);
-						
 						for(ResponseDoc d: json_response.getResponse().getSortedDocs()) {
 							LibraryId current = new LibraryId(d.getG(),d.getA(),d.getV());
 							verified_lids.add(current);

--- a/rest-backend/src/test/java/com/sap/psr/vulas/backend/rest/BugControllerTest.java
+++ b/rest-backend/src/test/java/com/sap/psr/vulas/backend/rest/BugControllerTest.java
@@ -553,17 +553,20 @@ public class BugControllerTest {
     	LibraryId lid2 = new LibraryId("com.foo", "bar", "1.0-copy");
     	libIdRepository.save(lid2);
 
-    	Library l1 = new Library("123FD");
+    	Library l1 = new Library("1E48256A2341047E7D729217ADEEC8217F6E3A1A");
     	l1.setLibraryId(lid1);
     	l1.setWellknownDigest(true);
     	libRepository.customSave(l1);
     	
-    	Library l2 = new Library("456EC");
+    	Library l2 = new Library("123FD");
     	l2.setLibraryId(lid2);
     	l2.setWellknownDigest(false);
     	libRepository.customSave(l2);
     	
-    	AffectedLibrary afflib1 = new AffectedLibrary(bug, lid1, true, null, null, null);
+		// the libraryId for l1 must have been replaced with the official one (from
+		// Maven Central) during the digest verification, thus we create the affected
+		// library for the latter
+    	AffectedLibrary afflib1 = new AffectedLibrary(bug, new LibraryId("commons-fileupload","commons-fileupload","1.2.2"), true, null, null, null);
     	afflib1.setSource(AffectedVersionSource.MANUAL);
     	
     	

--- a/rest-backend/src/test/java/com/sap/psr/vulas/backend/rest/HubIntegrationControllerTest.java
+++ b/rest-backend/src/test/java/com/sap/psr/vulas/backend/rest/HubIntegrationControllerTest.java
@@ -206,14 +206,17 @@ public class HubIntegrationControllerTest {
     
     @Test
     public void testGetHubAppVulnerabilities() throws Exception {
-    	final Library lib_foo = (Library)JacksonUtil.asObject(FileUtil.readFile(Paths.get("./src/test/resources/dummy_app/lib.json")), Library.class);
+    	final Library lib_foo = (Library)JacksonUtil.asObject(FileUtil.readFile(Paths.get("./src/test/resources/real_examples/lib_commons-fileupload-1.2.2.json")), Library.class);
     	this.libRepository.customSave(lib_foo);
     	
     	final Library lib_bar = (Library)JacksonUtil.asObject(FileUtil.readFile(Paths.get("./src/test/resources/dummy_app/lib_bar.json")), Library.class);
     	this.libRepository.customSave(lib_bar);
     	    	
-    	final Bug bug = (Bug)JacksonUtil.asObject(FileUtil.readFile(Paths.get("./src/test/resources/dummy_app/bug_foo.json")), Bug.class);
-    	this.bugRepository.customSave(bug,true);    	
+    	final Bug bug_foo = (Bug)JacksonUtil.asObject(FileUtil.readFile(Paths.get("./src/test/resources/dummy_app/bug_foo.json")), Bug.class);
+    	this.bugRepository.customSave(bug_foo,true);    	
+    	
+    	final Bug bug = (Bug)JacksonUtil.asObject(FileUtil.readFile(Paths.get("./src/test/resources/real_examples/bug_CVE-2014-0050.json")), Bug.class);
+    	this.bugRepository.customSave(bug,true);    
     	
     	// App with dependencies on foo and bar
     	final Application app = new Application(APP_GROUP, APP_ARTIFACT, "0.0." + APP_VERSION);

--- a/rest-backend/src/test/java/com/sap/psr/vulas/backend/rest/LibraryControllerTest.java
+++ b/rest-backend/src/test/java/com/sap/psr/vulas/backend/rest/LibraryControllerTest.java
@@ -52,8 +52,10 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.web.context.WebApplicationContext;
 
 import com.sap.psr.vulas.backend.model.Library;
+import com.sap.psr.vulas.backend.model.LibraryId;
 import com.sap.psr.vulas.backend.repo.LibraryRepository;
 import com.sap.psr.vulas.shared.categories.RequiresNetwork;
+import com.sap.psr.vulas.shared.enums.DigestAlgorithm;
 import com.sap.psr.vulas.shared.json.JacksonUtil;
 import com.sap.psr.vulas.shared.util.FileUtil;
 
@@ -190,4 +192,27 @@ public class LibraryControllerTest {
     	managed_lib = LibraryRepository.FILTER.findOne(libRepository.findByDigest("1E48256A2341047E7D729217ADEEC8217F6E3A1A"));
     	assertTrue(modifiedAt.getTimeInMillis()==managed_lib.getModifiedAt().getTimeInMillis());
     }
+    
+    /**
+     * post lib with well known digest, not well known libid
+     * @throws Exception
+     */
+    @Test
+    @Category(RequiresNetwork.class)
+    public void testPostNotWellKnownLibId() throws Exception {
+
+    	Library lib = new Library("1E48256A2341047E7D729217ADEEC8217F6E3A1A");
+    	lib.setDigestAlgorithm(DigestAlgorithm.SHA1);
+    	lib.setLibraryId(new LibraryId("bar","bar","0"));
+    	MockHttpServletRequestBuilder post_builder = post("/libs/")
+    			.content(JacksonUtil.asJsonString(lib).getBytes())
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON);
+    	mockMvc.perform(post_builder)	
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$.wellknownDigest", is(true)))
+                .andExpect(jsonPath("$.libraryId.artifact", is("commons-fileupload")))
+                .andExpect(jsonPath("$.digest", is("1E48256A2341047E7D729217ADEEC8217F6E3A1A")));
+        }
 }

--- a/rest-lib-utils/src/main/java/com/sap/psr/vulas/cia/util/ArtifactDownloader.java
+++ b/rest-lib-utils/src/main/java/com/sap/psr/vulas/cia/util/ArtifactDownloader.java
@@ -44,9 +44,9 @@ import org.springframework.web.client.RequestCallback;
 import org.springframework.web.client.ResponseExtractor;
 import org.springframework.web.client.RestTemplate;
 
-import com.sap.psr.vulas.cia.model.mavenCentral.MavenVersionsSearch;
-import com.sap.psr.vulas.cia.model.mavenCentral.ResponseDoc;
 import com.sap.psr.vulas.shared.json.model.Artifact;
+import com.sap.psr.vulas.shared.json.model.mavenCentral.MavenVersionsSearch;
+import com.sap.psr.vulas.shared.json.model.mavenCentral.ResponseDoc;
 import com.sap.psr.vulas.shared.util.VulasConfiguration;
 
 /**

--- a/rest-lib-utils/src/main/java/com/sap/psr/vulas/cia/util/ClassDownloader.java
+++ b/rest-lib-utils/src/main/java/com/sap/psr/vulas/cia/util/ClassDownloader.java
@@ -37,9 +37,9 @@ import org.apache.tomcat.jni.File;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sap.psr.vulas.cia.model.mavenCentral.ResponseDoc;
 import com.sap.psr.vulas.shared.enums.ProgrammingLanguage;
 import com.sap.psr.vulas.shared.json.model.Artifact;
+import com.sap.psr.vulas.shared.json.model.mavenCentral.ResponseDoc;
 
 /**
  * Retrieves the source or compiled code of Java classes from Maven artifacts.

--- a/rest-lib-utils/src/main/java/com/sap/psr/vulas/cia/util/MavenCentralWrapper.java
+++ b/rest-lib-utils/src/main/java/com/sap/psr/vulas/cia/util/MavenCentralWrapper.java
@@ -37,12 +37,12 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
-import com.sap.psr.vulas.cia.model.mavenCentral.MavenVersionsSearch;
-import com.sap.psr.vulas.cia.model.mavenCentral.ResponseDoc;
 import com.sap.psr.vulas.cia.util.ArtifactDownloader.DefaultRequestCallback;
 import com.sap.psr.vulas.cia.util.ArtifactDownloader.FileResponseExtractor;
 import com.sap.psr.vulas.shared.enums.ProgrammingLanguage;
 import com.sap.psr.vulas.shared.json.model.Artifact;
+import com.sap.psr.vulas.shared.json.model.mavenCentral.MavenVersionsSearch;
+import com.sap.psr.vulas.shared.json.model.mavenCentral.ResponseDoc;
 import com.sap.psr.vulas.shared.util.VulasConfiguration;
 
 

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/mavenCentral/MavenSearchResponse.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/mavenCentral/MavenSearchResponse.java
@@ -17,7 +17,7 @@
  *
  * Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved.
  */
-package com.sap.psr.vulas.cia.model.mavenCentral;
+package com.sap.psr.vulas.shared.json.model.mavenCentral;
 
 import java.util.Collection;
 import java.util.TreeSet;
@@ -32,6 +32,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class MavenSearchResponse {
 
 	private long numFound;
+	
+	private long start;
 	
 	private Collection<ResponseDoc> docs;
 	
@@ -52,6 +54,24 @@ public class MavenSearchResponse {
 	 * @param numFound a long.
 	 */
 	public void setNumFound(long numFound) { this.numFound = numFound; }
+
+	
+	/**
+	 * <p>Getter for the field <code>start</code>.</p>
+	 *
+	 * @return a long.
+	 */
+	public long getStart() {
+		return start;
+	}
+	/**
+	 * <p>Setter for the field <code>start</code>.</p>
+	 *
+	 * @param start a long.
+	 */
+	public void setStart(long start) {
+		this.start = start;
+	}
 
 	/**
 	 * <p>Getter for the field <code>docs</code>.</p>

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/mavenCentral/MavenVersionsSearch.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/mavenCentral/MavenVersionsSearch.java
@@ -17,7 +17,7 @@
  *
  * Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved.
  */
-package com.sap.psr.vulas.cia.model.mavenCentral;
+package com.sap.psr.vulas.shared.json.model.mavenCentral;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -37,13 +37,13 @@ public class MavenVersionsSearch {
 	/**
 	 * <p>Getter for the field <code>response</code>.</p>
 	 *
-	 * @return a {@link com.sap.psr.vulas.cia.model.mavenCentral.MavenSearchResponse} object.
+	 * @return a {@link com.sap.psr.vulas.shared.json.model.mavenCentral.MavenSearchResponse} object.
 	 */
 	public MavenSearchResponse getResponse() { return response; }
 	/**
 	 * <p>Setter for the field <code>response</code>.</p>
 	 *
-	 * @param response a {@link com.sap.psr.vulas.cia.model.mavenCentral.MavenSearchResponse} object.
+	 * @param response a {@link com.sap.psr.vulas.shared.json.model.mavenCentral.MavenSearchResponse} object.
 	 */
 	public void setResponse(MavenSearchResponse response) { this.response = response; }	
 }

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/mavenCentral/ResponseDoc.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/mavenCentral/ResponseDoc.java
@@ -17,7 +17,7 @@
  *
  * Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved.
  */
-package com.sap.psr.vulas.cia.model.mavenCentral;
+package com.sap.psr.vulas.shared.json.model.mavenCentral;
 
 import java.util.Collection;
 import java.util.regex.Matcher;
@@ -59,6 +59,8 @@ public class ResponseDoc implements Comparable {
 	private long timestamp;
 	
 	private Collection<String> ec = null;
+	
+	private Collection<String> tags = null;
 	
 	/**
 	 * <p>Constructor for ResponseDoc.</p>
@@ -172,6 +174,24 @@ public class ResponseDoc implements Comparable {
 	 */
 	public void setEc(Collection<String> ec) { this.ec = ec; }
 	
+	/**
+	 * <p>Getter for the field <code>tags</code>.</p>
+	 *
+	 * @return a {@link java.util.Collection} object.
+	 */
+	public Collection<String> getTags() {
+		return tags;
+	}
+
+	/**
+	 * <p>Setter for the field <code>tags</code>.</p>
+	 *
+	 * @param tags a {@link java.util.Collection} object.
+	 */
+	public void setTags(Collection<String> tags) {
+		this.tags = tags;
+	}
+
 	/**
 	 * <p>availableWith.</p>
 	 *


### PR DESCRIPTION
When libraries are saved, the backend checks whether the digest is wellKnown using one of the implemented verifiers, i.e. Maven Central and Pypi.

Problem Observed:
Until now we didn't check whether the libraryId provided by the client is also well known, as a result we may end up with not-well-known library ids saved to the database (even for well known digests).

Solution:
The verifyDigest method now checks that the provided libraryId is wellKnown, and replaces it with the well known one if it isn't (it takes the first in case multiple ones are returned). Note that:

- the verification is not done in the prePersist method anylonger because we need to save the transient LibraryId entity in case it gets replaced.
- the verification now happens every time a library is saved (thus replacing also the url and timestamp of the verification)
