### PR TITLE
default for unassessed bugs in report set to all

### DIFF
--- a/lang/src/main/resources/vulas-core.properties
+++ b/lang/src/main/resources/vulas-core.properties
@@ -174,9 +174,9 @@ vulas.report.exemptScope = TEST, PROVIDED
 #   known: Only un-assessed vulns in archives known to Maven Central will be ignored
 #   off: Never ignore
 #
-# Default: known
+# Default: all
 # Note: Available as of Vulas 2.3.7
-vulas.report.exceptionExcludeUnassessed = known
+vulas.report.exceptionExcludeUnassessed = all
 
 # Specified vulnerabilities will not cause a build exception
 # A wildcard can be used for <digest> to indicate that a bug is exempted no matter in which library


### PR DESCRIPTION
Reverting default for unassessed bugs to 'all' (config vulas.report.exceptionExcludeUnassessed)