### PR TITLE
Fix docs and cli release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,12 @@ matrix:
     install:
     - docker build --tag docs ./docs
     - docker network create docs
+    addons:
+      apt:
+        packages:
+          - python3.4
+          - python3-pip
+          - python3-setuptools
     script:
     - docker run --rm --network=docs -d --name docs --hostname docs -p 8000:8000 docs
     - sleep 10
@@ -114,7 +120,7 @@ matrix:
     deploy:
     - provider: script
       skip_cleanup: true
-      script: cd docs && pip install -r requirements.txt && sed -i.bak '/dev_addr/d' mkdocs.yml && python docs.py public --mkghdeploy
+      script: cd docs && pip3 install wheel --user && pip3 install -r requirements.txt --user && sed -i.bak '/dev_addr/d' mkdocs.yml && python3 docs.py public --mkghdeploy
       on:
         tags: true
         condition: "$TRAVIS_TAG =~ ^[0-9]+\\.[0-9]+\\.[0-9]+(\\..+)?$"

--- a/.travis/package_steady_cli.sh
+++ b/.travis/package_steady_cli.sh
@@ -16,8 +16,8 @@ WORKDIR="/tmp/cli"
 mkdir -p  $WORKDIR/steady-cli/app
 mkdir -p  $WORKDIR/steady-cli/instr
 
-mv ../lang-java/target/lang-java-${VULAS_RELEASE}-jar-with-dependencies.jar $WORKDIR/steady-cli/instr
-mv ../cli-scanner/target/cli-scanner-${VULAS_RELEASE}-jar-with-dependencies.jar $WORKDIR/steady-cli/steady-cli-${VULAS_RELEASE}-jar-with-dependencies.jar
+wget -P $WORKDIR/steady-cli/instr https://repo1.maven.org/maven2/com/sap/research/security/vulas/lang-java/${VULAS_RELEASE}/lang-java-${VULAS_RELEASE}-jar-with-dependencies.jar
+wget -O $WORKDIR/steady-cli/steady-cli-${VULAS_RELEASE}-jar-with-dependencies.jar https://repo1.maven.org/maven2/com/sap/research/security/vulas/cli-scanner/${VULAS_RELEASE}/cli-scanner-${VULAS_RELEASE}-jar-with-dependencies.jar
 cp vulas-custom.properties.sample $WORKDIR/steady-cli
 zip -r $WORKDIR/steady-cli-$VULAS_RELEASE.zip  $WORKDIR/steady-cli/
 echo "Done"


### PR DESCRIPTION
- The cli release was failing because some point of time the build artifacts were getting cleared. So changed it to wget, where we get the artifacts online
- The docs release was causing permission issues. Hence, added --user and used python3

#### `TODO`s

- [ ] Tests
- [ ] Documentation