### PR TITLE
Fix: Duplicate content-type header in NVD-rest

### DIFF
--- a/rest-nvd/app/main.py
+++ b/rest-nvd/app/main.py
@@ -51,7 +51,7 @@ def get_vuln_data(vuln_id):
 
         data = jsonify({'extended_data': {'license': lic, 'language': lang}, 'nvd_data': data})
 
-    return data, 200, {'Content-Type': 'application/json; charset=utf-8'}
+    return data, 200
 
 
 @app.route(PREFIX_URL + '/status')


### PR DESCRIPTION
<!-- Describe your contribution -->
Currently, any request to `nvd/vulnerabilities/<cve-id>`

returns a response with the headers

```
Content-Type: application/json
Content-Type: application/json; charset=utf-8
```

Since flask since version 1.1.0 automatically sets the `Content-Type: application/json`
see https://flask.palletsprojects.com/en/1.1.x/quickstart/#apis-with-json

The code
`return data, 200, {'Content-Type': 'application/json; charset=utf-8'}`
results in the duplicate Content-Type header. 

This PR fixes the duplicate code.

<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [ ] Tests
- [ ] Documentation