### PR TITLE
Change order of layers for `rest-ndv`'s Dockerfile

### DIFF
--- a/rest-nvd/Dockerfile
+++ b/rest-nvd/Dockerfile
@@ -1,5 +1,7 @@
 FROM tiangolo/meinheld-gunicorn-flask:python3.7
 
+LABEL maintainer="Vulas vulas-dev@listserv.sap.com"
+
 WORKDIR /app
 
 RUN pip install --upgrade pip

--- a/rest-nvd/Dockerfile
+++ b/rest-nvd/Dockerfile
@@ -1,9 +1,12 @@
 FROM tiangolo/meinheld-gunicorn-flask:python3.7
 
-COPY . /app
+WORKDIR /app
 
 RUN pip install --upgrade pip
 RUN pip install plac \
     tqdm \
     requests
+
+COPY . /app
+
 RUN pip install .


### PR DESCRIPTION
<!-- Describe your contribution -->
Hi all,

this changes the order of layers in the `rest-nvd`'s `Dockerfile` so to cache and reuse them even when the business logic inside `/app` has changed

I have also some suggestions:

- better to declare all the requirements in the `setup.py` and get rid of the `pip install plac tqdm  requests` step in the `Dockerfile`
- @henrikplate, shouln't we update all the `LABEL maintainer="Vulas vulas-dev@listserv.sap.com"`s of our `Dockerfile` to something more Eclipsy?
- you can try to use the `alpine` version of `tiangolo/meinheld-gunicorn-flask` so to be a bit more `secure` and `fast`.
- maybe you can upload the image to the Docker Hub, I guess some people could benefit
- [pin](https://stackoverflow.com/a/8161816/3482533) the version of the deps in the `setup.py`
<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [ ] Tests
- [ ] Documentation