### PR TITLE
Update log4j to log4j2

### DIFF
--- a/cli-scanner/src/main/java/com/sap/psr/vulas/cli/VulasCli.java
+++ b/cli-scanner/src/main/java/com/sap/psr/vulas/cli/VulasCli.java
@@ -25,8 +25,8 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.goals.AbstractGoal;
 import com.sap.psr.vulas.goals.GoalConfigurationException;
@@ -44,7 +44,7 @@ import com.sap.psr.vulas.shared.json.model.Space;
  */
 public class VulasCli {
 
-	private static final Log log = LogFactory.getLog(VulasCli.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(VulasCli.class);
 
 	private static GoalType goalType = null;
 

--- a/cli-scanner/src/main/java/com/sap/psr/vulas/cli/VulasCli.java
+++ b/cli-scanner/src/main/java/com/sap/psr/vulas/cli/VulasCli.java
@@ -44,7 +44,7 @@ import com.sap.psr.vulas.shared.json.model.Space;
  */
 public class VulasCli {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(VulasCli.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private static GoalType goalType = null;
 

--- a/cli-scanner/src/test/resources/java-app/com/acme/ArchiveServlet.java
+++ b/cli-scanner/src/test/resources/java-app/com/acme/ArchiveServlet.java
@@ -23,7 +23,7 @@ import org.apache.commons.fileupload.servlet.ServletFileUpload;
 
 public class ArchiveServlet extends HttpServlet {
 
-	//private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ArchiveServlet.class);
+	//private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	// Just to have a static initializer as part of the test app
 	static String nonsense = null;

--- a/cli-scanner/src/test/resources/java-app/com/acme/ArchiveServlet.java
+++ b/cli-scanner/src/test/resources/java-app/com/acme/ArchiveServlet.java
@@ -23,7 +23,7 @@ import org.apache.commons.fileupload.servlet.ServletFileUpload;
 
 public class ArchiveServlet extends HttpServlet {
 
-	//private static final Log log = LogFactory.getLog(ArchiveServlet.class);
+	//private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ArchiveServlet.class);
 	
 	// Just to have a static initializer as part of the test app
 	static String nonsense = null;

--- a/lang-java-reach-soot/src/main/java/com/sap/psr/vulas/cg/soot/SootCallgraphConstructor.java
+++ b/lang-java-reach-soot/src/main/java/com/sap/psr/vulas/cg/soot/SootCallgraphConstructor.java
@@ -47,7 +47,7 @@ import java.util.*;
  */
 public class SootCallgraphConstructor implements ICallgraphConstructor {
 
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SootCallgraphConstructor.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
     /** Constant <code>FRAMEWORK="soot"</code> */
     public static final String FRAMEWORK = "soot";

--- a/lang-java-reach-soot/src/main/java/com/sap/psr/vulas/cg/soot/SootCallgraphConstructor.java
+++ b/lang-java-reach-soot/src/main/java/com/sap/psr/vulas/cg/soot/SootCallgraphConstructor.java
@@ -31,8 +31,8 @@ import com.sap.psr.vulas.shared.json.model.Application;
 import com.sap.psr.vulas.shared.util.StringUtil;
 import com.sap.psr.vulas.shared.util.VulasConfiguration;
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import soot.*;
 import soot.jimple.infoflow.entryPointCreators.IEntryPointCreator;
 import soot.jimple.toolkits.callgraph.CallGraph;
@@ -47,7 +47,7 @@ import java.util.*;
  */
 public class SootCallgraphConstructor implements ICallgraphConstructor {
 
-    private static final Log log = LogFactory.getLog(SootCallgraphConstructor.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SootCallgraphConstructor.class);
 
     /** Constant <code>FRAMEWORK="soot"</code> */
     public static final String FRAMEWORK = "soot";

--- a/lang-java-reach-wala/pom.xml
+++ b/lang-java-reach-wala/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.sap.research.security.vulas</groupId>
             <artifactId>lang-java-reach</artifactId>
-            <version>3.1.12</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/lang-java-reach-wala/src/main/java/com/sap/psr/vulas/cg/wala/WalaCallgraphConstructor.java
+++ b/lang-java-reach-wala/src/main/java/com/sap/psr/vulas/cg/wala/WalaCallgraphConstructor.java
@@ -26,8 +26,8 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
@@ -64,7 +64,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class WalaCallgraphConstructor implements ICallgraphConstructor {
 
-    private static final Log log = LogFactory.getLog(WalaCallgraphConstructor.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(WalaCallgraphConstructor.class);
     /** Constant <code>FRAMEWORK="wala"</code> */
     public static final String FRAMEWORK = "wala";
 

--- a/lang-java-reach-wala/src/main/java/com/sap/psr/vulas/cg/wala/WalaCallgraphConstructor.java
+++ b/lang-java-reach-wala/src/main/java/com/sap/psr/vulas/cg/wala/WalaCallgraphConstructor.java
@@ -64,7 +64,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class WalaCallgraphConstructor implements ICallgraphConstructor {
 
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(WalaCallgraphConstructor.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
     /** Constant <code>FRAMEWORK="wala"</code> */
     public static final String FRAMEWORK = "wala";
 

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/A2CGoal.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/A2CGoal.java
@@ -21,8 +21,8 @@ package com.sap.psr.vulas.cg;
 
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.enums.GoalType;
 import com.sap.psr.vulas.shared.enums.PathSource;
@@ -35,7 +35,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class A2CGoal extends AbstractReachGoal {
 	
-	private static final Log log = LogFactory.getLog(A2CGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(A2CGoal.class);
 
 	private Set<com.sap.psr.vulas.shared.json.model.ConstructId> entryPoints = null;
 	

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/A2CGoal.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/A2CGoal.java
@@ -35,7 +35,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class A2CGoal extends AbstractReachGoal {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(A2CGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private Set<com.sap.psr.vulas.shared.json.model.ConstructId> entryPoints = null;
 	

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/AbstractReachGoal.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/AbstractReachGoal.java
@@ -24,8 +24,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.sap.psr.vulas.shared.enums.GoalClient;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnectionException;
 import com.sap.psr.vulas.backend.BackendConnector;
@@ -46,7 +46,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public abstract class AbstractReachGoal extends AbstractAppGoal {
 
-    private static final Log log = LogFactory.getLog(AbstractReachGoal.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AbstractReachGoal.class);
 
     private Set<Path> preparedDepClasspath = new HashSet<Path>();
 

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/AbstractReachGoal.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/AbstractReachGoal.java
@@ -46,7 +46,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public abstract class AbstractReachGoal extends AbstractAppGoal {
 
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AbstractReachGoal.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
     private Set<Path> preparedDepClasspath = new HashSet<Path>();
 

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/Callgraph.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/Callgraph.java
@@ -33,8 +33,8 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
@@ -58,7 +58,7 @@ import javassist.NotFoundException;
  */
 public class Callgraph {
 
-	private static final Log log = LogFactory.getLog(Callgraph.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(Callgraph.class);
 
 	private int nodeCount = 0;
 	private int edgeCount = 0;

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/Callgraph.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/Callgraph.java
@@ -58,7 +58,7 @@ import javassist.NotFoundException;
  */
 public class Callgraph {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(Callgraph.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private int nodeCount = 0;
 	private int edgeCount = 0;

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/CallgraphPathSearch.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/CallgraphPathSearch.java
@@ -26,8 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.util.StopWatch;
 
@@ -37,7 +37,7 @@ import com.sap.psr.vulas.shared.util.StopWatch;
  */
 public class CallgraphPathSearch implements Runnable {
 	
-	private static final Log log = LogFactory.getLog(CallgraphPathSearch.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CallgraphPathSearch.class);
 
 	private Callgraph graph = null;
 	

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/CallgraphPathSearch.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/CallgraphPathSearch.java
@@ -37,7 +37,7 @@ import com.sap.psr.vulas.shared.util.StopWatch;
  */
 public class CallgraphPathSearch implements Runnable {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CallgraphPathSearch.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private Callgraph graph = null;
 	

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/CallgraphReachableSearch.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/CallgraphReachableSearch.java
@@ -27,8 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.ibm.wala.util.graph.Graph;
 import com.sap.psr.vulas.shared.util.StopWatch;
@@ -39,7 +39,7 @@ import com.sap.psr.vulas.shared.util.StopWatch;
  */
 public class CallgraphReachableSearch implements Runnable {
 
-	private static final Log log = LogFactory.getLog(CallgraphReachableSearch.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CallgraphReachableSearch.class);
 
 	private Callgraph graph = null;
 

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/CallgraphReachableSearch.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/CallgraphReachableSearch.java
@@ -39,7 +39,7 @@ import com.sap.psr.vulas.shared.util.StopWatch;
  */
 public class CallgraphReachableSearch implements Runnable {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CallgraphReachableSearch.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private Callgraph graph = null;
 

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/DepthFirstGetPaths.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/DepthFirstGetPaths.java
@@ -36,7 +36,7 @@ import com.sap.psr.vulas.shared.json.model.ConstructId;
  */
 public class DepthFirstGetPaths extends AbstractGetPaths {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DepthFirstGetPaths.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 			
 	private long start_millis = System.currentTimeMillis(), end_millis = System.currentTimeMillis();	
 	

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/DepthFirstGetPaths.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/DepthFirstGetPaths.java
@@ -24,8 +24,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.ibm.wala.util.graph.Graph;
 import com.sap.psr.vulas.shared.json.model.ConstructId;
@@ -36,7 +36,7 @@ import com.sap.psr.vulas.shared.json.model.ConstructId;
  */
 public class DepthFirstGetPaths extends AbstractGetPaths {
 	
-	private static final Log log = LogFactory.getLog(DepthFirstGetPaths.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DepthFirstGetPaths.class);
 			
 	private long start_millis = System.currentTimeMillis(), end_millis = System.currentTimeMillis();	
 	

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/MethodNameFilter.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/MethodNameFilter.java
@@ -41,7 +41,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class MethodNameFilter {
 
-	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(MethodNameFilter.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private static MethodNameFilter instance = null;
 	

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/MethodNameFilter.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/MethodNameFilter.java
@@ -27,8 +27,8 @@ package com.sap.psr.vulas.cg;
 import java.util.Set;
 
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.ConstructId;
 import com.sap.psr.vulas.backend.BackendConnector;
@@ -41,7 +41,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class MethodNameFilter {
 
-	private static Log log = LogFactory.getLog(MethodNameFilter.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(MethodNameFilter.class);
 	
 	private static MethodNameFilter instance = null;
 	

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/PathSimilarity.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/PathSimilarity.java
@@ -25,8 +25,8 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 /**
  * <p>PathSimilarity class.</p>
@@ -34,7 +34,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class PathSimilarity {
 	
-	private static final Log log = LogFactory.getLog( PathSimilarity.class );
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger( PathSimilarity.class );
 
 	//ArrayList: every path has a unique index
 	ArrayList<LinkedList<String>> paths = null;

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/PrunedGraphGetPaths.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/PrunedGraphGetPaths.java
@@ -26,8 +26,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.ibm.wala.util.graph.Graph;
 import com.sap.psr.vulas.shared.json.model.ConstructId;
@@ -38,7 +38,7 @@ import com.sap.psr.vulas.shared.json.model.ConstructId;
  */
 public class PrunedGraphGetPaths extends AbstractGetPaths {
 	
-	private static final Log log = LogFactory.getLog(PrunedGraphGetPaths.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PrunedGraphGetPaths.class);
 	
 	private long start_millis = System.currentTimeMillis(), end_millis = System.currentTimeMillis();	
 

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/PrunedGraphGetPaths.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/PrunedGraphGetPaths.java
@@ -38,7 +38,7 @@ import com.sap.psr.vulas.shared.json.model.ConstructId;
  */
 public class PrunedGraphGetPaths extends AbstractGetPaths {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PrunedGraphGetPaths.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private long start_millis = System.currentTimeMillis(), end_millis = System.currentTimeMillis();	
 

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/ReachabilityAnalyzer.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/ReachabilityAnalyzer.java
@@ -67,7 +67,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class ReachabilityAnalyzer implements Runnable {
 
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ReachabilityAnalyzer.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
     private static int THREAD_COUNT = 0;
 

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/ReachabilityAnalyzer.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/ReachabilityAnalyzer.java
@@ -39,8 +39,8 @@ import java.util.concurrent.TimeUnit;
 import com.sap.psr.vulas.cg.spi.CallgraphConstructorFactory;
 import com.sap.psr.vulas.cg.spi.ICallgraphConstructor;
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -67,7 +67,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class ReachabilityAnalyzer implements Runnable {
 
-    private static final Log log = LogFactory.getLog(ReachabilityAnalyzer.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ReachabilityAnalyzer.class);
 
     private static int THREAD_COUNT = 0;
 

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/spi/CallgraphConstructorFactory.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/spi/CallgraphConstructorFactory.java
@@ -30,8 +30,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.cg.ReachabilityConfiguration;
 import com.sap.psr.vulas.shared.json.model.Application;
@@ -46,7 +46,7 @@ public class CallgraphConstructorFactory {
     /** Constant <code>classLoaderToFindPlugins</code> */
     public static ClassLoader classLoaderToFindPlugins = Thread.currentThread().getContextClassLoader();
 
-    private static final Log log = LogFactory.getLog(CallgraphConstructorFactory.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CallgraphConstructorFactory.class);
 
     /**
      * Build a call graph constructor, searching the service registry for a service implementation that registers itself using the given string

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/spi/CallgraphConstructorFactory.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/spi/CallgraphConstructorFactory.java
@@ -46,7 +46,7 @@ public class CallgraphConstructorFactory {
     /** Constant <code>classLoaderToFindPlugins</code> */
     public static ClassLoader classLoaderToFindPlugins = Thread.currentThread().getContextClassLoader();
 
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CallgraphConstructorFactory.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
     /**
      * Build a call graph constructor, searching the service registry for a service implementation that registers itself using the given string

--- a/lang-java/src/main/java/com/sap/psr/vulas/bytecode/BytecodeComparator.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/bytecode/BytecodeComparator.java
@@ -17,8 +17,8 @@ import java.util.jar.JarFile;
 import java.util.zip.ZipException;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.sap.psr.vulas.backend.BackendConnectionException;
@@ -43,7 +43,7 @@ import com.sap.psr.vulas.sign.SignatureFactory;
 
 public class BytecodeComparator  {
 	
-	private static final Log log = LogFactory.getLog(BytecodeComparator.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BytecodeComparator.class);
 	
 	private GoalContext context;
 	private Map<Class<?>,StdDeserializer<?>> custom_deserializers = new HashMap<Class<?>,StdDeserializer<?>>();

--- a/lang-java/src/main/java/com/sap/psr/vulas/bytecode/BytecodeComparator.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/bytecode/BytecodeComparator.java
@@ -43,7 +43,7 @@ import com.sap.psr.vulas.sign.SignatureFactory;
 
 public class BytecodeComparator  {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BytecodeComparator.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private GoalContext context;
 	private Map<Class<?>,StdDeserializer<?>> custom_deserializers = new HashMap<Class<?>,StdDeserializer<?>>();

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/AarAnalyzer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/AarAnalyzer.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.jar.JarFile;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.FileAnalysisException;
 import com.sap.psr.vulas.shared.util.FileUtil;
@@ -36,7 +36,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
  */
 public class AarAnalyzer extends JarAnalyzer {
 
-	private static final Log log = LogFactory.getLog(AarAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AarAnalyzer.class);
 	
 	private static final String CLASSES_JAR = "classes.jar";
 	

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/AarAnalyzer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/AarAnalyzer.java
@@ -36,7 +36,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
  */
 public class AarAnalyzer extends JarAnalyzer {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AarAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private static final String CLASSES_JAR = "classes.jar";
 	

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/ArchiveAnalysisManager.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/ArchiveAnalysisManager.java
@@ -35,8 +35,8 @@ import java.util.concurrent.TimeUnit;
 
 import javax.validation.constraints.NotNull;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.FileAnalyzer;
 import com.sap.psr.vulas.core.util.CoreConfiguration;
@@ -54,7 +54,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class ArchiveAnalysisManager {
 
-	private static final Log log = LogFactory.getLog(ArchiveAnalysisManager.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ArchiveAnalysisManager.class);
 
 	private ExecutorService pool;
 	

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/ArchiveAnalysisManager.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/ArchiveAnalysisManager.java
@@ -54,7 +54,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class ArchiveAnalysisManager {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ArchiveAnalysisManager.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private ExecutorService pool;
 	

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/ClassFileAnalyzer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/ClassFileAnalyzer.java
@@ -27,8 +27,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.Construct;
 import com.sap.psr.vulas.ConstructId;
@@ -46,7 +46,7 @@ import javassist.CtClass;
  */
 public class ClassFileAnalyzer implements FileAnalyzer {
 
-	private static final Log log = LogFactory.getLog(ClassFileAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ClassFileAnalyzer.class);
 
 	/** The file to be analyzed. */
 	private File file = null;

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/ClassFileAnalyzer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/ClassFileAnalyzer.java
@@ -46,7 +46,7 @@ import javassist.CtClass;
  */
 public class ClassFileAnalyzer implements FileAnalyzer {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ClassFileAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/** The file to be analyzed. */
 	private File file = null;

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/JarAnalyzer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/JarAnalyzer.java
@@ -75,7 +75,7 @@ import javassist.NotFoundException;
  */
 public class JarAnalyzer implements Callable<FileAnalyzer>, JarEntryWriter, FileAnalyzer {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JarAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private static final ClassPool CLASSPOOL = ClassPool.getDefault();
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/JarAnalyzer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/JarAnalyzer.java
@@ -43,8 +43,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
@@ -75,7 +75,7 @@ import javassist.NotFoundException;
  */
 public class JarAnalyzer implements Callable<FileAnalyzer>, JarEntryWriter, FileAnalyzer {
 
-	private static final Log log = LogFactory.getLog(JarAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JarAnalyzer.class);
 
 	private static final ClassPool CLASSPOOL = ClassPool.getDefault();
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/JarWriter.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/JarWriter.java
@@ -60,7 +60,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class JarWriter {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JarWriter.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	public final SimpleDateFormat dateFormat = new SimpleDateFormat("d MMM yyyy HH:mm:ss");
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/JarWriter.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/JarWriter.java
@@ -46,8 +46,8 @@ import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.shared.util.DigestUtil;
@@ -60,7 +60,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class JarWriter {
 
-	private static final Log log = LogFactory.getLog(JarWriter.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JarWriter.class);
 
 	public final SimpleDateFormat dateFormat = new SimpleDateFormat("d MMM yyyy HH:mm:ss");
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/JavaFileAnalyzer2.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/JavaFileAnalyzer2.java
@@ -46,8 +46,8 @@ import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.misc.NotNull;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.Construct;
 import com.sap.psr.vulas.ConstructId;
@@ -66,7 +66,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
  */
 public class JavaFileAnalyzer2 extends JavaParserBaseListener implements FileAnalyzer {
 
-	private static final Log log = LogFactory.getLog(JavaFileAnalyzer2.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JavaFileAnalyzer2.class);
 
 	/**
 	 * All Java constructs found in the given Java file, created through visiting relevant nodes of the ANTLR parse tree.

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/JavaFileAnalyzer2.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/JavaFileAnalyzer2.java
@@ -66,7 +66,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
  */
 public class JavaFileAnalyzer2 extends JavaParserBaseListener implements FileAnalyzer {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JavaFileAnalyzer2.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * All Java constructs found in the given Java file, created through visiting relevant nodes of the ANTLR parse tree.

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/JavaId.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/JavaId.java
@@ -31,8 +31,8 @@ import java.util.Set;
 
 import javax.validation.constraints.NotNull;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -50,7 +50,7 @@ import com.sap.psr.vulas.shared.json.JsonBuilder;
  */
 public abstract class JavaId extends ConstructId {
 
-	private static final Log log = LogFactory.getLog(JavaId.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JavaId.class);
 
 	/** Supported Java programming constructs. */
 	public static enum Type { PACKAGE, CLASS, ENUM, INTERFACE, NESTED_CLASS, CONSTRUCTOR, METHOD, CLASSINIT };

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/JavaId.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/JavaId.java
@@ -50,7 +50,7 @@ import com.sap.psr.vulas.shared.json.JsonBuilder;
  */
 public abstract class JavaId extends ConstructId {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JavaId.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/** Supported Java programming constructs. */
 	public static enum Type { PACKAGE, CLASS, ENUM, INTERFACE, NESTED_CLASS, CONSTRUCTOR, METHOD, CLASSINIT };

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/PomParser.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/PomParser.java
@@ -35,7 +35,7 @@ import com.sap.psr.vulas.shared.json.model.LibraryId;
  */
 public class PomParser extends DefaultHandler {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PomParser.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private static final String[] pg = new String[] {"project", "parent", "groupId"};
 	private static final String[] pa = new String[] {"project", "parent", "artifactId"};

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/PomParser.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/PomParser.java
@@ -22,8 +22,8 @@ package com.sap.psr.vulas.java;
 import java.util.Arrays;
 import java.util.Stack;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
@@ -35,7 +35,7 @@ import com.sap.psr.vulas.shared.json.model.LibraryId;
  */
 public class PomParser extends DefaultHandler {
 
-	private static final Log log = LogFactory.getLog(PomParser.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PomParser.class);
 	
 	private static final String[] pg = new String[] {"project", "parent", "groupId"};
 	private static final String[] pa = new String[] {"project", "parent", "artifactId"};

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/WarAnalyzer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/WarAnalyzer.java
@@ -59,7 +59,7 @@ import javassist.NotFoundException;
  */
 public class WarAnalyzer extends JarAnalyzer {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(WarAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private static final String INCL_SPACE = "vulas.core.instr.static.inclSpace";
 	private static final String INCL_BACKEND_URL = "vulas.core.instr.static.inclBackendUrl";

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/WarAnalyzer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/WarAnalyzer.java
@@ -36,8 +36,8 @@ import java.util.jar.JarEntry;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.ConstructId;
 import com.sap.psr.vulas.FileAnalysisException;
@@ -59,7 +59,7 @@ import javassist.NotFoundException;
  */
 public class WarAnalyzer extends JarAnalyzer {
 
-	private static final Log log = LogFactory.getLog(WarAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(WarAnalyzer.class);
 	
 	private static final String INCL_SPACE = "vulas.core.instr.static.inclSpace";
 	private static final String INCL_BACKEND_URL = "vulas.core.instr.static.inclBackendUrl";

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/decompiler/ProcyonDecompiler.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/decompiler/ProcyonDecompiler.java
@@ -38,7 +38,7 @@ import com.strobel.decompiler.PlainTextOutput;
  */
 public class ProcyonDecompiler implements IDecompiler {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ProcyonDecompiler.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	/** {@inheritDoc} */
 	@Override

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/decompiler/ProcyonDecompiler.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/decompiler/ProcyonDecompiler.java
@@ -25,8 +25,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
 
 import com.sap.psr.vulas.shared.util.FileUtil;
 import com.strobel.decompiler.Decompiler;
@@ -39,7 +38,7 @@ import com.strobel.decompiler.PlainTextOutput;
  */
 public class ProcyonDecompiler implements IDecompiler {
 
-	private static final Log log =LogFactory.getLog(ProcyonDecompiler.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ProcyonDecompiler.class);
 	
 	/** {@inheritDoc} */
 	@Override

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/goals/CheckBytecodeGoal.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/goals/CheckBytecodeGoal.java
@@ -25,8 +25,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnector;
 import com.sap.psr.vulas.bytecode.BytecodeComparator;
@@ -50,7 +50,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
  */
 public class CheckBytecodeGoal extends AbstractAppGoal {
 
-	private static final Log log = LogFactory.getLog(CheckBytecodeGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CheckBytecodeGoal.class);
 
 	/**
 	 * <p>

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/goals/CheckBytecodeGoal.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/goals/CheckBytecodeGoal.java
@@ -50,7 +50,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
  */
 public class CheckBytecodeGoal extends AbstractAppGoal {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CheckBytecodeGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * <p>

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/goals/InstrGoal.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/goals/InstrGoal.java
@@ -45,7 +45,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class InstrGoal extends AbstractAppGoal {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(InstrGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private Path libPath = null;
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/goals/InstrGoal.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/goals/InstrGoal.java
@@ -24,8 +24,8 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.goals.AbstractAppGoal;
@@ -45,7 +45,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class InstrGoal extends AbstractAppGoal {
 
-	private static final Log log = LogFactory.getLog(InstrGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(InstrGoal.class);
 
 	private Path libPath = null;
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/sign/ASTSignatureComparator.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/sign/ASTSignatureComparator.java
@@ -27,8 +27,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.sign.Signature;
 import com.sap.psr.vulas.sign.SignatureChange;
@@ -56,7 +56,7 @@ import ch.uzh.ifi.seal.changedistiller.treedifferencing.matching.measure.TokenBa
 public class ASTSignatureComparator implements SignatureComparator {
 
 
-	private static final Log log = LogFactory.getLog(ASTSignatureComparator.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ASTSignatureComparator.class);
 	
 	//If a construct under test contains 50% of the fixes, it is said to contain the Security Fixes
 	// TODO : (A more robust scheme than a simple percentage might be better)

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/sign/ASTSignatureComparator.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/sign/ASTSignatureComparator.java
@@ -56,7 +56,7 @@ import ch.uzh.ifi.seal.changedistiller.treedifferencing.matching.measure.TokenBa
 public class ASTSignatureComparator implements SignatureComparator {
 
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ASTSignatureComparator.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	//If a construct under test contains 50% of the fixes, it is said to contain the Security Fixes
 	// TODO : (A more robust scheme than a simple percentage might be better)

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/sign/ASTUtil.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/sign/ASTUtil.java
@@ -40,7 +40,7 @@ import ch.uzh.ifi.seal.changedistiller.treedifferencing.Node;
  */
 public class ASTUtil {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ASTUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	public static enum NODE_COMPARE_MODE { ENTITY_TYPE, VALUE };
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/sign/ASTUtil.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/sign/ASTUtil.java
@@ -26,8 +26,8 @@ import java.util.Set;
 
 import javax.validation.constraints.NotNull;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import ch.uzh.ifi.seal.changedistiller.model.classifiers.ChangeType;
 import ch.uzh.ifi.seal.changedistiller.model.classifiers.EntityType;
@@ -40,7 +40,7 @@ import ch.uzh.ifi.seal.changedistiller.treedifferencing.Node;
  */
 public class ASTUtil {
 
-	private static final Log log = LogFactory.getLog(ASTUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ASTUtil.class);
 
 	public static enum NODE_COMPARE_MODE { ENTITY_TYPE, VALUE };
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/sign/CompilationUtils.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/sign/CompilationUtils.java
@@ -23,8 +23,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.eclipse.jdt.internal.compiler.CompilationResult;
 import org.eclipse.jdt.internal.compiler.DefaultErrorHandlingPolicies;
 import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
@@ -51,7 +51,7 @@ import ch.uzh.ifi.seal.changedistiller.ast.java.JavaCompilation;
  */
 public final class CompilationUtils {
 	
-	private static final Log log = LogFactory.getLog(CompilationUtils.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CompilationUtils.class);
 
 	private CompilationUtils() {}
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/sign/CompilationUtils.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/sign/CompilationUtils.java
@@ -51,7 +51,7 @@ import ch.uzh.ifi.seal.changedistiller.ast.java.JavaCompilation;
  */
 public final class CompilationUtils {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CompilationUtils.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private CompilationUtils() {}
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/sign/JavaSignatureFactory.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/sign/JavaSignatureFactory.java
@@ -30,8 +30,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.Construct;
 import com.sap.psr.vulas.FileAnalysisException;
@@ -61,7 +61,7 @@ import javassist.bytecode.ClassFile;
  */
 public class JavaSignatureFactory implements SignatureFactory {
 
-	private static final Log log = LogFactory.getLog(JavaSignatureFactory.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JavaSignatureFactory.class);
 
 	/**
 	 * Cache of contructs, so that the decompilation and parsing must not be done over and over again.

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/sign/JavaSignatureFactory.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/sign/JavaSignatureFactory.java
@@ -61,7 +61,7 @@ import javassist.bytecode.ClassFile;
  */
 public class JavaSignatureFactory implements SignatureFactory {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JavaSignatureFactory.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * Cache of contructs, so that the decompilation and parsing must not be done over and over again.

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/sign/UniqueNameNormalizer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/sign/UniqueNameNormalizer.java
@@ -45,7 +45,7 @@ import ch.uzh.ifi.seal.changedistiller.model.entities.SourceCodeEntity;
  */
 public class UniqueNameNormalizer implements IUniqueNameNormalizer {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(UniqueNameNormalizer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private static final Pattern CONSTANT_PATTERN = Pattern.compile("([0-9a-zA-Z_\\.]+)\\.([0-9A-Z_]+)");
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/sign/UniqueNameNormalizer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/sign/UniqueNameNormalizer.java
@@ -28,8 +28,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.ConstructId;
 import com.sap.psr.vulas.core.util.SignatureConfiguration;
@@ -45,7 +45,7 @@ import ch.uzh.ifi.seal.changedistiller.model.entities.SourceCodeEntity;
  */
 public class UniqueNameNormalizer implements IUniqueNameNormalizer {
 
-	private static final Log log = LogFactory.getLog(UniqueNameNormalizer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(UniqueNameNormalizer.class);
 
 	private static final Pattern CONSTANT_PATTERN = Pattern.compile("([0-9a-zA-Z_\\.]+)\\.([0-9A-Z_]+)");
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/sign/gson/ASTConstructBodySignatureDeserializer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/sign/gson/ASTConstructBodySignatureDeserializer.java
@@ -45,7 +45,7 @@ import org.apache.logging.log4j.Logger;
  *
  */
 public class ASTConstructBodySignatureDeserializer extends StdDeserializer<ASTConstructBodySignature> {
-private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ASTConstructBodySignatureDeserializer.class);
+private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	/**
 	 * <p>Constructor for ASTConstructBodySignatureDeserializer.</p>
 	 */

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/sign/gson/ASTConstructBodySignatureDeserializer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/sign/gson/ASTConstructBodySignatureDeserializer.java
@@ -37,15 +37,15 @@ import ch.uzh.ifi.seal.changedistiller.model.entities.SourceCodeEntity;
 import ch.uzh.ifi.seal.changedistiller.treedifferencing.Node;
 
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 /**
  * <p>ASTConstructBodySignatureDeserializer class.</p>
  *
  */
 public class ASTConstructBodySignatureDeserializer extends StdDeserializer<ASTConstructBodySignature> {
-private static final Log log = LogFactory.getLog(ASTConstructBodySignatureDeserializer.class);
+private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ASTConstructBodySignatureDeserializer.class);
 	/**
 	 * <p>Constructor for ASTConstructBodySignatureDeserializer.</p>
 	 */

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/sign/gson/ASTSignatureChangeDeserializer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/sign/gson/ASTSignatureChangeDeserializer.java
@@ -104,7 +104,7 @@ import ch.uzh.ifi.seal.changedistiller.model.entities.Update;
  */
 public class ASTSignatureChangeDeserializer extends StdDeserializer<SignatureChange> {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ASTSignatureChangeDeserializer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	// Values for JsonElement Names, used as a member name during deserialization
 	// We need only to change these value if the name/value pair of a JsonElement

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/sign/gson/ASTSignatureChangeDeserializer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/sign/gson/ASTSignatureChangeDeserializer.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -104,7 +104,7 @@ import ch.uzh.ifi.seal.changedistiller.model.entities.Update;
  */
 public class ASTSignatureChangeDeserializer extends StdDeserializer<SignatureChange> {
 
-	private static final Log log = LogFactory.getLog(ASTSignatureChangeDeserializer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ASTSignatureChangeDeserializer.class);
 
 	// Values for JsonElement Names, used as a member name during deserialization
 	// We need only to change these value if the name/value pair of a JsonElement

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/tasks/JavaBomTask.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/tasks/JavaBomTask.java
@@ -59,7 +59,7 @@ import com.sap.psr.vulas.tasks.AbstractBomTask;
  */
 public class JavaBomTask extends AbstractBomTask {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JavaBomTask.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private static final String[] EXT_FILTER = new String[] { "jar", "war", "class", "java", "aar" };
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/tasks/JavaBomTask.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/tasks/JavaBomTask.java
@@ -27,8 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.ConstructId;
 import com.sap.psr.vulas.DirAnalyzer;
@@ -59,7 +59,7 @@ import com.sap.psr.vulas.tasks.AbstractBomTask;
  */
 public class JavaBomTask extends AbstractBomTask {
 
-	private static final Log log = LogFactory.getLog(JavaBomTask.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JavaBomTask.class);
 	
 	private static final String[] EXT_FILTER = new String[] { "jar", "war", "class", "java", "aar" };
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/ClassPoolUpdater.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/ClassPoolUpdater.java
@@ -47,7 +47,7 @@ import javassist.NotFoundException;
  */
 public class ClassPoolUpdater {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ClassPoolUpdater.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private static ClassPoolUpdater instance = null;
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/ClassPoolUpdater.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/ClassPoolUpdater.java
@@ -29,8 +29,8 @@ import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.ConstructId;
 import com.sap.psr.vulas.java.JavaId;
@@ -47,7 +47,7 @@ import javassist.NotFoundException;
  */
 public class ClassPoolUpdater {
 
-	private static final Log log = LogFactory.getLog(ClassPoolUpdater.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ClassPoolUpdater.class);
 
 	private static ClassPoolUpdater instance = null;
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/ClassVisitor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/ClassVisitor.java
@@ -69,7 +69,7 @@ public class ClassVisitor {
 	private static Logger log = null;
 	private static final Logger getLog() {
 		if(ClassVisitor.log==null)
-			ClassVisitor.log = org.apache.logging.log4j.LogManager.getLogger(ClassVisitor.class);
+			ClassVisitor.log = org.apache.logging.log4j.LogManager.getLogger();
 		return ClassVisitor.log;
 	}
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/ClassVisitor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/ClassVisitor.java
@@ -33,8 +33,7 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
 
 import com.sap.psr.vulas.ConstructId;
 import com.sap.psr.vulas.core.util.CoreConfiguration;
@@ -67,10 +66,10 @@ public class ClassVisitor {
 
 	// ====================================== STATIC MEMBERS
 
-	private static Log log = null;
-	private static final Log getLog() {
+	private static Logger log = null;
+	private static final Logger getLog() {
 		if(ClassVisitor.log==null)
-			ClassVisitor.log = LogFactory.getLog(ClassVisitor.class);
+			ClassVisitor.log = org.apache.logging.log4j.LogManager.getLogger(ClassVisitor.class);
 		return ClassVisitor.log;
 	}
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/DynamicTransformer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/DynamicTransformer.java
@@ -28,8 +28,8 @@ import java.security.ProtectionDomain;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.java.JarAnalyzer;
@@ -56,7 +56,7 @@ public class DynamicTransformer implements ClassFileTransformer {
 
 	// ====================================== STATIC MEMBERS
 
-	private static final Log log = LogFactory.getLog(DynamicTransformer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DynamicTransformer.class);
 
 	private static DynamicTransformer instance = null;
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/DynamicTransformer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/DynamicTransformer.java
@@ -56,7 +56,7 @@ public class DynamicTransformer implements ClassFileTransformer {
 
 	// ====================================== STATIC MEMBERS
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DynamicTransformer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private static DynamicTransformer instance = null;
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/ExecutionMonitor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/ExecutionMonitor.java
@@ -24,8 +24,7 @@ import java.util.List;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
 
 import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.goals.AbstractGoal;
@@ -47,7 +46,7 @@ public class ExecutionMonitor {
 
 	private static ExecutionMonitor instance = null;
 
-	private static Log log = null;
+	private static Logger log = null;
 	
 	private static boolean PAUSE_COLLECTION = false;
 
@@ -105,9 +104,9 @@ public class ExecutionMonitor {
 		return ExecutionMonitor.instance;
 	}
 	
-	private static final Log getLog() {
+	private static final Logger getLog() {
 		if(ExecutionMonitor.log==null)
-			ExecutionMonitor.log = LogFactory.getLog(ExecutionMonitor.class);
+			ExecutionMonitor.log = org.apache.logging.log4j.LogManager.getLogger(ExecutionMonitor.class);
 		return ExecutionMonitor.log;
 	}
 	

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/ExecutionMonitor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/ExecutionMonitor.java
@@ -106,7 +106,7 @@ public class ExecutionMonitor {
 	
 	private static final Logger getLog() {
 		if(ExecutionMonitor.log==null)
-			ExecutionMonitor.log = org.apache.logging.log4j.LogManager.getLogger(ExecutionMonitor.class);
+			ExecutionMonitor.log = org.apache.logging.log4j.LogManager.getLogger();
 		return ExecutionMonitor.log;
 	}
 	

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/InstrumentationControl.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/InstrumentationControl.java
@@ -30,8 +30,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnectionException;
 import com.sap.psr.vulas.backend.BackendConnector;
@@ -62,7 +62,7 @@ public class InstrumentationControl {
 
 	public static enum InstrumentationMetrics { classesTotal, classesInstrumentedSuccess, classesInstrumentedFailure, classesAlreadyInstrumented };
 
-	private static final Log log = LogFactory.getLog(InstrumentationControl.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(InstrumentationControl.class);
 
 	/**
 	 * All instances of the class, used to produce overall instrumentation statistics.

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/InstrumentationControl.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/InstrumentationControl.java
@@ -62,7 +62,7 @@ public class InstrumentationControl {
 
 	public static enum InstrumentationMetrics { classesTotal, classesInstrumentedSuccess, classesInstrumentedFailure, classesAlreadyInstrumented };
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(InstrumentationControl.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * All instances of the class, used to produce overall instrumentation statistics.

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/InstrumentorFactory.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/InstrumentorFactory.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.shared.util.VulasConfiguration;
@@ -36,7 +36,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class InstrumentorFactory {
 
-	private static final Log log = LogFactory.getLog(InstrumentorFactory.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(InstrumentorFactory.class);
 
 	private static List<IInstrumentor> instrumentors = null;
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/InstrumentorFactory.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/InstrumentorFactory.java
@@ -36,7 +36,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class InstrumentorFactory {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(InstrumentorFactory.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private static List<IInstrumentor> instrumentors = null;
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/LoaderHierarchy.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/LoaderHierarchy.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class LoaderHierarchy {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(LoaderHierarchy.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private Map<ClassLoader, Loader> loaderMap = new HashMap<ClassLoader, Loader>();
 	

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/LoaderHierarchy.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/LoaderHierarchy.java
@@ -22,15 +22,15 @@ package com.sap.psr.vulas.monitor;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 /**
  * Offers methods to create and interact with a hierarchy of {@link ClassLoader}s and {@link Loader}s.
  */
 public class LoaderHierarchy {
 	
-	private static final Log log = LogFactory.getLog(LoaderHierarchy.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(LoaderHierarchy.class);
 
 	private Map<ClassLoader, Loader> loaderMap = new HashMap<ClassLoader, Loader>();
 	

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/UploadScheduler.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/UploadScheduler.java
@@ -33,7 +33,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class UploadScheduler extends Observable implements Runnable, Observer {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(UploadScheduler.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private long millis = -1;
 	private int batchSize = -1;

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/UploadScheduler.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/UploadScheduler.java
@@ -22,8 +22,8 @@ package com.sap.psr.vulas.monitor;
 import java.util.Observable;
 import java.util.Observer;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 
 /**
@@ -33,7 +33,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class UploadScheduler extends Observable implements Runnable, Observer {
 	
-	private static final Log log = LogFactory.getLog(UploadScheduler.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(UploadScheduler.class);
 	
 	private long millis = -1;
 	private int batchSize = -1;

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/slice/SliceInstrumentor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/slice/SliceInstrumentor.java
@@ -28,8 +28,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.ConstructId;
 import com.sap.psr.vulas.backend.BackendConnectionException;
@@ -53,7 +53,7 @@ public class SliceInstrumentor extends AbstractInstrumentor {
 
 	// ====================================== STATIC MEMBERS
 
-	private static final Log log = LogFactory.getLog(SliceInstrumentor.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SliceInstrumentor.class);
 
 	// ====================================== INSTANCE MEMBERS
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/slice/SliceInstrumentor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/slice/SliceInstrumentor.java
@@ -53,7 +53,7 @@ public class SliceInstrumentor extends AbstractInstrumentor {
 
 	// ====================================== STATIC MEMBERS
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SliceInstrumentor.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	// ====================================== INSTANCE MEMBERS
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/touch/ConstructIdUtil.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/touch/ConstructIdUtil.java
@@ -44,7 +44,7 @@ public class ConstructIdUtil {
 	private static Logger log = null;
 	private static final Logger getLog() {
 		if(ConstructIdUtil.log==null)
-			ConstructIdUtil.log = org.apache.logging.log4j.LogManager.getLogger(ConstructIdUtil.class);
+			ConstructIdUtil.log = org.apache.logging.log4j.LogManager.getLogger();
 		return ConstructIdUtil.log;
 	}
 	

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/touch/ConstructIdUtil.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/touch/ConstructIdUtil.java
@@ -23,8 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
 
 import com.sap.psr.vulas.ConstructId;
 import com.sap.psr.vulas.backend.BackendConnectionException;
@@ -42,10 +41,10 @@ import com.sap.psr.vulas.monitor.ClassVisitor;
  */
 public class ConstructIdUtil {
 
-	private static Log log = null;
-	private static final Log getLog() {
+	private static Logger log = null;
+	private static final Logger getLog() {
 		if(ConstructIdUtil.log==null)
-			ConstructIdUtil.log = LogFactory.getLog(ConstructIdUtil.class);
+			ConstructIdUtil.log = org.apache.logging.log4j.LogManager.getLogger(ConstructIdUtil.class);
 		return ConstructIdUtil.log;
 	}
 	

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/touch/TouchPointCollector.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/touch/TouchPointCollector.java
@@ -32,8 +32,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -61,10 +60,10 @@ public class TouchPointCollector {
 
 	// STATIC MEMBERS
 
-	private static Log log = null;
-	private static final Log getLog() {
+	private static Logger log = null;
+	private static final Logger getLog() {
 		if(TouchPointCollector.log==null)
-			TouchPointCollector.log = LogFactory.getLog(TouchPointCollector.class);
+			TouchPointCollector.log = org.apache.logging.log4j.LogManager.getLogger(TouchPointCollector.class);
 		return TouchPointCollector.log;
 	}
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/touch/TouchPointCollector.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/touch/TouchPointCollector.java
@@ -63,7 +63,7 @@ public class TouchPointCollector {
 	private static Logger log = null;
 	private static final Logger getLog() {
 		if(TouchPointCollector.log==null)
-			TouchPointCollector.log = org.apache.logging.log4j.LogManager.getLogger(TouchPointCollector.class);
+			TouchPointCollector.log = org.apache.logging.log4j.LogManager.getLogger();
 		return TouchPointCollector.log;
 	}
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/touch/TouchPointInstrumentor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/touch/TouchPointInstrumentor.java
@@ -22,8 +22,8 @@ package com.sap.psr.vulas.monitor.touch;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.goals.AbstractGoal;
 import com.sap.psr.vulas.java.JavaId;
@@ -41,7 +41,7 @@ import javassist.CtBehavior;
  */
 public class TouchPointInstrumentor extends AbstractInstrumentor {
 
-	private static final Log log = LogFactory.getLog(TouchPointInstrumentor.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(TouchPointInstrumentor.class);
 
 	/** {@inheritDoc} */
 	public void instrument(StringBuffer _code, JavaId _jid, CtBehavior _behavior, ClassVisitor _cv) throws CannotCompileException {

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/touch/TouchPointInstrumentor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/touch/TouchPointInstrumentor.java
@@ -41,7 +41,7 @@ import javassist.CtBehavior;
  */
 public class TouchPointInstrumentor extends AbstractInstrumentor {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(TouchPointInstrumentor.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/** {@inheritDoc} */
 	public void instrument(StringBuffer _code, JavaId _jid, CtBehavior _behavior, ClassVisitor _cv) throws CannotCompileException {

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/SingleStackTraceInstrumentor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/SingleStackTraceInstrumentor.java
@@ -47,7 +47,7 @@ public class SingleStackTraceInstrumentor extends AbstractTraceInstrumentor {
 
 	// ====================================== STATIC MEMBERS
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SingleStackTraceInstrumentor.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	// ====================================== INSTANCE MEMBERS
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/SingleStackTraceInstrumentor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/SingleStackTraceInstrumentor.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.ConstructId;
 import com.sap.psr.vulas.backend.BackendConnectionException;
@@ -47,7 +47,7 @@ public class SingleStackTraceInstrumentor extends AbstractTraceInstrumentor {
 
 	// ====================================== STATIC MEMBERS
 
-	private static final Log log = LogFactory.getLog(SingleStackTraceInstrumentor.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SingleStackTraceInstrumentor.class);
 
 	// ====================================== INSTANCE MEMBERS
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/StackTraceInstrumentor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/StackTraceInstrumentor.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.ConstructId;
 import com.sap.psr.vulas.backend.BackendConnectionException;
@@ -45,7 +45,7 @@ public class StackTraceInstrumentor extends AbstractTraceInstrumentor {
 
 	// ====================================== STATIC MEMBERS
 
-	private static final Log log = LogFactory.getLog(StackTraceInstrumentor.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(StackTraceInstrumentor.class);
 
 	// ====================================== INSTANCE MEMBERS
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/StackTraceInstrumentor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/StackTraceInstrumentor.java
@@ -45,7 +45,7 @@ public class StackTraceInstrumentor extends AbstractTraceInstrumentor {
 
 	// ====================================== STATIC MEMBERS
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(StackTraceInstrumentor.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	// ====================================== INSTANCE MEMBERS
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/StackTraceUtil.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/StackTraceUtil.java
@@ -68,7 +68,7 @@ public class StackTraceUtil {
 	private static Logger log = null;
 	private static final Logger getLog() {
 		if(StackTraceUtil.log==null)
-			StackTraceUtil.log =  org.apache.logging.log4j.LogManager.getLogger(StackTraceUtil.class);
+			StackTraceUtil.log =  org.apache.logging.log4j.LogManager.getLogger();
 		return StackTraceUtil.log;
 	}
 	

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/StackTraceUtil.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/StackTraceUtil.java
@@ -34,8 +34,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
 
 import com.sap.psr.vulas.ConstructId;
 import com.sap.psr.vulas.java.JavaClassId;
@@ -66,10 +65,10 @@ import javassist.NotFoundException;
  */
 public class StackTraceUtil {
 
-	private static Log log = null;
-	private static final Log getLog() {
+	private static Logger log = null;
+	private static final Logger getLog() {
 		if(StackTraceUtil.log==null)
-			StackTraceUtil.log =  LogFactory.getLog(StackTraceUtil.class);
+			StackTraceUtil.log =  org.apache.logging.log4j.LogManager.getLogger(StackTraceUtil.class);
 		return StackTraceUtil.log;
 	}
 	

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/TraceCollector.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/TraceCollector.java
@@ -37,8 +37,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.ConstructId;
 import com.sap.psr.vulas.FileAnalysisException;
@@ -73,7 +73,7 @@ public class TraceCollector {
 
 	//private static boolean PAUSE_COLLECTION = false;
 
-	private static Log log = null;
+	private static Logger log = null;
 
 	// INSTANCE MEMBERS
 
@@ -160,9 +160,9 @@ public class TraceCollector {
 		return TraceCollector.instance;
 	}
 
-	private static final Log getLog() {
+	private static final Logger getLog() {
 		if(TraceCollector.log==null)
-			TraceCollector.log = LogFactory.getLog(TraceCollector.class);
+			TraceCollector.log = org.apache.logging.log4j.LogManager.getLogger(TraceCollector.class);
 		return TraceCollector.log;
 	}
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/TraceCollector.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/TraceCollector.java
@@ -162,7 +162,7 @@ public class TraceCollector {
 
 	private static final Logger getLog() {
 		if(TraceCollector.log==null)
-			TraceCollector.log = org.apache.logging.log4j.LogManager.getLogger(TraceCollector.class);
+			TraceCollector.log = org.apache.logging.log4j.LogManager.getLogger();
 		return TraceCollector.log;
 	}
 

--- a/lang-java/src/test/java/com/sap/psr/vulas/java/JsonHelperTest.java
+++ b/lang-java/src/test/java/com/sap/psr/vulas/java/JsonHelperTest.java
@@ -25,8 +25,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.junit.Test;
 
 import com.sap.psr.vulas.FileAnalysisException;
@@ -35,7 +35,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
 
 public class JsonHelperTest {
 
-	private static final Log log = LogFactory.getLog(JsonHelperTest.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JsonHelperTest.class);
 
 	/**
 	 * Analyzes a given JAR twice and checks whether the produced JSON is equal.

--- a/lang-java/src/test/java/com/sap/psr/vulas/java/JsonHelperTest.java
+++ b/lang-java/src/test/java/com/sap/psr/vulas/java/JsonHelperTest.java
@@ -35,7 +35,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
 
 public class JsonHelperTest {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JsonHelperTest.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * Analyzes a given JAR twice and checks whether the produced JSON is equal.

--- a/lang-java/src/test/java/com/sap/psr/vulas/java/sign/ASTSignatureComparatorTest.java
+++ b/lang-java/src/test/java/com/sap/psr/vulas/java/sign/ASTSignatureComparatorTest.java
@@ -65,7 +65,7 @@ import com.sap.psr.vulas.sign.SignatureFactory;
  */
 public class ASTSignatureComparatorTest {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ASTSignatureComparatorTest.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	Map<Class<?>,StdDeserializer<?>> custom_deserializers = new HashMap<Class<?>,StdDeserializer<?>>();
 

--- a/lang-java/src/test/java/com/sap/psr/vulas/java/sign/ASTSignatureComparatorTest.java
+++ b/lang-java/src/test/java/com/sap/psr/vulas/java/sign/ASTSignatureComparatorTest.java
@@ -33,8 +33,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -65,7 +65,7 @@ import com.sap.psr.vulas.sign.SignatureFactory;
  */
 public class ASTSignatureComparatorTest {
 
-	private static final Log log = LogFactory.getLog(ASTSignatureComparatorTest.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ASTSignatureComparatorTest.class);
 
 	Map<Class<?>,StdDeserializer<?>> custom_deserializers = new HashMap<Class<?>,StdDeserializer<?>>();
 

--- a/lang-java/src/test/java/com/sap/psr/vulas/java/sign/gson/ASTDeserializeSignComparatorTest.java
+++ b/lang-java/src/test/java/com/sap/psr/vulas/java/sign/gson/ASTDeserializeSignComparatorTest.java
@@ -28,8 +28,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -44,7 +44,7 @@ import com.sap.psr.vulas.sign.SignatureChange;
 
 public class ASTDeserializeSignComparatorTest {
 
-	private static final Log log = LogFactory.getLog(ASTDeserializeSignComparatorTest.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ASTDeserializeSignComparatorTest.class);
 	
 	final Gson gson = GsonHelper.getCustomGsonBuilder().create();
 

--- a/lang-java/src/test/java/com/sap/psr/vulas/java/sign/gson/ASTDeserializeSignComparatorTest.java
+++ b/lang-java/src/test/java/com/sap/psr/vulas/java/sign/gson/ASTDeserializeSignComparatorTest.java
@@ -44,7 +44,7 @@ import com.sap.psr.vulas.sign.SignatureChange;
 
 public class ASTDeserializeSignComparatorTest {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ASTDeserializeSignComparatorTest.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	final Gson gson = GsonHelper.getCustomGsonBuilder().create();
 

--- a/lang-java/src/test/resources/methodBody/AbstractCommonHostnameVerifierDef.java
+++ b/lang-java/src/test/resources/methodBody/AbstractCommonHostnameVerifierDef.java
@@ -41,8 +41,8 @@ import java.util.StringTokenizer;
 
 import javax.net.ssl.SSLException;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.apache.http.annotation.Immutable;
 import org.apache.http.conn.util.InetAddressUtils;
 
@@ -78,7 +78,7 @@ public abstract class AbstractCommonHostnameVerifier extends AbstractBaseHostnam
         Arrays.sort(BAD_COUNTRY_2LDS);
     }
 
-    private final Log log = LogFactory.getLog(getClass());
+    private final Logger log = org.apache.logging.log4j.LogManager.getLogger(getClass());
 
     @Override
     public final void verify(final String host, final X509Certificate cert)

--- a/lang-java/src/test/resources/methodBody/AbstractCommonHostnameVerifierFix.java
+++ b/lang-java/src/test/resources/methodBody/AbstractCommonHostnameVerifierFix.java
@@ -47,8 +47,8 @@ import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 import javax.net.ssl.SSLException;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.apache.http.annotation.Immutable;
 import org.apache.http.conn.util.InetAddressUtils;
 
@@ -84,7 +84,7 @@ public abstract class AbstractCommonHostnameVerifier extends AbstractBaseHostnam
         Arrays.sort(BAD_COUNTRY_2LDS);
     }
 
-    private final Log log = LogFactory.getLog(getClass());
+    private final Logger log = org.apache.logging.log4j.LogManager.getLogger(getClass());
 
     @Override
     public final void verify(final String host, final X509Certificate cert)

--- a/lang-java/src/test/resources/methodBody/AbstractVerifierDef.java
+++ b/lang-java/src/test/resources/methodBody/AbstractVerifierDef.java
@@ -46,8 +46,8 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.apache.http.annotation.Immutable;
 import org.apache.http.conn.util.InetAddressUtils;
 
@@ -79,7 +79,7 @@ public abstract class AbstractVerifier implements X509HostnameVerifier {
         Arrays.sort(BAD_COUNTRY_2LDS);
     }
 
-    private final Log log = LogFactory.getLog(getClass());
+    private final Logger log = org.apache.logging.log4j.LogManager.getLogger(getClass());
 
     public AbstractVerifier() {
         super();

--- a/lang-java/src/test/resources/methodBody/AbstractVerifierFix.java
+++ b/lang-java/src/test/resources/methodBody/AbstractVerifierFix.java
@@ -52,8 +52,8 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.apache.http.annotation.Immutable;
 import org.apache.http.conn.util.InetAddressUtils;
 
@@ -85,7 +85,7 @@ public abstract class AbstractVerifier implements X509HostnameVerifier {
         Arrays.sort(BAD_COUNTRY_2LDS);
     }
 
-    private final Log log = LogFactory.getLog(getClass());
+    private final Logger log = org.apache.logging.log4j.LogManager.getLogger(getClass());
 
     public AbstractVerifier() {
         super();

--- a/lang-java/src/test/resources/methodBody/J_AbstractVerifier_F.java
+++ b/lang-java/src/test/resources/methodBody/J_AbstractVerifier_F.java
@@ -52,8 +52,8 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.apache.http.annotation.Immutable;
 import org.apache.http.conn.util.InetAddressUtils;
 
@@ -85,7 +85,7 @@ public abstract class AbstractVerifier implements X509HostnameVerifier {
         Arrays.sort(BAD_COUNTRY_2LDS);
     }
 
-    private final Log log = LogFactory.getLog(getClass());
+    private final Logger log = org.apache.logging.log4j.LogManager.getLogger(getClass());
 
     public AbstractVerifier() {
         super();

--- a/lang-java/src/test/resources/methodBody/J_AbstractVerifier_V.java
+++ b/lang-java/src/test/resources/methodBody/J_AbstractVerifier_V.java
@@ -46,8 +46,8 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.apache.http.annotation.Immutable;
 import org.apache.http.conn.util.InetAddressUtils;
 
@@ -79,7 +79,7 @@ public abstract class AbstractVerifier implements X509HostnameVerifier {
         Arrays.sort(BAD_COUNTRY_2LDS);
     }
 
-    private final Log log = LogFactory.getLog(getClass());
+    private final Logger log = org.apache.logging.log4j.LogManager.getLogger(getClass());
 
     public AbstractVerifier() {
         super();

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/ProcessWrapper.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/ProcessWrapper.java
@@ -27,8 +27,8 @@ import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.util.FileUtil;
 import com.sap.psr.vulas.shared.util.StringUtil;
@@ -39,7 +39,7 @@ import com.sap.psr.vulas.shared.util.StringUtil;
  */
 public class ProcessWrapper implements Runnable {
 	
-	private static Log log = LogFactory.getLog(ProcessWrapper.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(ProcessWrapper.class);
 	
 	private static final Pattern ALLOWED = Pattern.compile("[\\.\\-\\w=]+");
 	

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/ProcessWrapper.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/ProcessWrapper.java
@@ -39,7 +39,7 @@ import com.sap.psr.vulas.shared.util.StringUtil;
  */
 public class ProcessWrapper implements Runnable {
 	
-	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(ProcessWrapper.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private static final Pattern ALLOWED = Pattern.compile("[\\.\\-\\w=]+");
 	

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/Python335FileAnalyzer.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/Python335FileAnalyzer.java
@@ -59,7 +59,7 @@ import com.sap.psr.vulas.shared.util.StringUtil;
  */
 public class Python335FileAnalyzer extends Python335BaseListener implements FileAnalyzer {  
 
-	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(Python335FileAnalyzer.class);
+	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	protected Map<ConstructId, Construct> constructs = null;
 

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/Python335FileAnalyzer.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/Python335FileAnalyzer.java
@@ -38,8 +38,8 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.Construct;
 import com.sap.psr.vulas.ConstructId;
@@ -59,7 +59,7 @@ import com.sap.psr.vulas.shared.util.StringUtil;
  */
 public class Python335FileAnalyzer extends Python335BaseListener implements FileAnalyzer {  
 
-	private final static Log log = LogFactory.getLog(Python335FileAnalyzer.class);
+	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(Python335FileAnalyzer.class);
 
 	protected Map<ConstructId, Construct> constructs = null;
 

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/Python3FileAnalyzer.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/Python3FileAnalyzer.java
@@ -37,8 +37,8 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.Construct;
 import com.sap.psr.vulas.ConstructId;
@@ -58,7 +58,7 @@ import com.sap.psr.vulas.shared.util.StringUtil;
  */
 public class Python3FileAnalyzer extends Python3BaseListener implements FileAnalyzer {  
 
-	private final static Log log = LogFactory.getLog(Python3FileAnalyzer.class);
+	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(Python3FileAnalyzer.class);
 
 	protected Map<ConstructId, Construct> constructs = null;
 

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/Python3FileAnalyzer.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/Python3FileAnalyzer.java
@@ -58,7 +58,7 @@ import com.sap.psr.vulas.shared.util.StringUtil;
  */
 public class Python3FileAnalyzer extends Python3BaseListener implements FileAnalyzer {  
 
-	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(Python3FileAnalyzer.class);
+	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	protected Map<ConstructId, Construct> constructs = null;
 

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/PythonArchiveAnalyzer.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/PythonArchiveAnalyzer.java
@@ -40,8 +40,8 @@ import java.util.zip.ZipInputStream;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.Construct;
 import com.sap.psr.vulas.ConstructId;
@@ -61,7 +61,7 @@ import com.sap.psr.vulas.shared.util.StringUtil;
  */
 public class PythonArchiveAnalyzer implements FileAnalyzer {
 
-	private static final Log log = LogFactory.getLog(PythonArchiveAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PythonArchiveAnalyzer.class);
 
 	Map<ConstructId, Construct> constructs = new TreeMap<ConstructId, Construct>();
 

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/PythonArchiveAnalyzer.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/PythonArchiveAnalyzer.java
@@ -61,7 +61,7 @@ import com.sap.psr.vulas.shared.util.StringUtil;
  */
 public class PythonArchiveAnalyzer implements FileAnalyzer {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PythonArchiveAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	Map<ConstructId, Construct> constructs = new TreeMap<ConstructId, Construct>();
 

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/PythonFileAnalyzer.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/PythonFileAnalyzer.java
@@ -50,7 +50,7 @@ import com.sap.psr.vulas.shared.util.StringUtil;
  */
 public class PythonFileAnalyzer implements FileAnalyzer {
 
-	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(PythonFileAnalyzer.class);
+	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private FileAnalyzer analyzer = null;
 

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/PythonFileAnalyzer.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/PythonFileAnalyzer.java
@@ -33,8 +33,8 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.regex.Pattern;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.Construct;
 import com.sap.psr.vulas.ConstructId;
@@ -50,7 +50,7 @@ import com.sap.psr.vulas.shared.util.StringUtil;
  */
 public class PythonFileAnalyzer implements FileAnalyzer {
 
-	private final static Log log = LogFactory.getLog(PythonFileAnalyzer.class);
+	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(PythonFileAnalyzer.class);
 
 	private FileAnalyzer analyzer = null;
 

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/pip/PipInstalledPackage.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/pip/PipInstalledPackage.java
@@ -53,7 +53,7 @@ import com.sap.psr.vulas.shared.util.StringList;
  */
 public class PipInstalledPackage implements Comparable {
 
-	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(PipInstalledPackage.class);
+	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private static final String LOCATION = "Location";
 	private static final String REQUIRES = "Requires";

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/pip/PipInstalledPackage.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/pip/PipInstalledPackage.java
@@ -26,8 +26,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.Construct;
 import com.sap.psr.vulas.ConstructId;
@@ -53,7 +53,7 @@ import com.sap.psr.vulas.shared.util.StringList;
  */
 public class PipInstalledPackage implements Comparable {
 
-	private final static Log log = LogFactory.getLog(PipInstalledPackage.class);
+	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(PipInstalledPackage.class);
 
 	private static final String LOCATION = "Location";
 	private static final String REQUIRES = "Requires";

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/pip/PipWrapper.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/pip/PipWrapper.java
@@ -60,7 +60,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class PipWrapper {
 
-	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(PipWrapper.class);
+	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	static final Pattern DOWNLOAD_PATTERN = Pattern.compile("^\\s*Downloading\\s*(http\\S*).*$");
 

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/pip/PipWrapper.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/pip/PipWrapper.java
@@ -39,8 +39,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.python.ProcessWrapper;
 import com.sap.psr.vulas.python.ProcessWrapperException;
@@ -60,7 +60,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class PipWrapper {
 
-	private final static Log log = LogFactory.getLog(PipWrapper.class);
+	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(PipWrapper.class);
 
 	static final Pattern DOWNLOAD_PATTERN = Pattern.compile("^\\s*Downloading\\s*(http\\S*).*$");
 

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/pip/PyWrapper.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/pip/PyWrapper.java
@@ -38,7 +38,7 @@ import com.sap.psr.vulas.shared.util.StringUtil;
  */
 public class PyWrapper {
 	
-	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(PyWrapper.class);
+	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private Path pathToPython = null;
 	

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/pip/PyWrapper.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/pip/PyWrapper.java
@@ -25,8 +25,8 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.python.ProcessWrapperException;
 import com.sap.psr.vulas.shared.util.FileUtil;
@@ -38,7 +38,7 @@ import com.sap.psr.vulas.shared.util.StringUtil;
  */
 public class PyWrapper {
 	
-	private final static Log log = LogFactory.getLog(PyWrapper.class);
+	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(PyWrapper.class);
 	
 	private Path pathToPython = null;
 	

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/sign/PythonSignatureFactory.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/sign/PythonSignatureFactory.java
@@ -21,8 +21,8 @@ package com.sap.psr.vulas.python.sign;
 
 import java.io.File;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.Construct;
 import com.sap.psr.vulas.FileAnalysisException;
@@ -44,7 +44,7 @@ import com.sap.psr.vulas.sign.SignatureFactory;
  */
 public class PythonSignatureFactory implements SignatureFactory {
 
-	private static final Log log = LogFactory.getLog(PythonSignatureFactory.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PythonSignatureFactory.class);
 
 	/**
 	 * {@inheritDoc}

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/sign/PythonSignatureFactory.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/sign/PythonSignatureFactory.java
@@ -44,7 +44,7 @@ import com.sap.psr.vulas.sign.SignatureFactory;
  */
 public class PythonSignatureFactory implements SignatureFactory {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PythonSignatureFactory.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * {@inheritDoc}

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/tasks/PythonBomTask.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/tasks/PythonBomTask.java
@@ -26,8 +26,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.ConstructId;
 import com.sap.psr.vulas.FileAnalysisException;
@@ -59,7 +59,7 @@ import com.sap.psr.vulas.tasks.AbstractBomTask;
  */
 public class PythonBomTask extends AbstractBomTask {
 
-	private static final Log log = LogFactory.getLog(PythonBomTask.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PythonBomTask.class);
 
 	private static final String[] EXT_FILTER = new String[] { "whl", "egg", "py" };
 

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/tasks/PythonBomTask.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/tasks/PythonBomTask.java
@@ -59,7 +59,7 @@ import com.sap.psr.vulas.tasks.AbstractBomTask;
  */
 public class PythonBomTask extends AbstractBomTask {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PythonBomTask.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private static final String[] EXT_FILTER = new String[] { "whl", "egg", "py" };
 

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/utils/PythonConfiguration.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/utils/PythonConfiguration.java
@@ -32,8 +32,8 @@ import java.util.jar.Manifest;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnectionException;
 import com.sap.psr.vulas.backend.BackendConnector;
@@ -52,7 +52,7 @@ import com.sap.psr.vulas.sign.SignatureFactory;
  */
 public class PythonConfiguration {
 
-	private static final Log log = LogFactory.getLog(PythonConfiguration.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PythonConfiguration.class);
 
 	/** Constant <code>PY_BOM_IGNORE_PACKS="vulas.core.bom.python.ignorePacks"</code> */
 	public final static String PY_BOM_IGNORE_PACKS = "vulas.core.bom.python.ignorePacks";

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/utils/PythonConfiguration.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/utils/PythonConfiguration.java
@@ -52,7 +52,7 @@ import com.sap.psr.vulas.sign.SignatureFactory;
  */
 public class PythonConfiguration {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PythonConfiguration.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/** Constant <code>PY_BOM_IGNORE_PACKS="vulas.core.bom.python.ignorePacks"</code> */
 	public final static String PY_BOM_IGNORE_PACKS = "vulas.core.bom.python.ignorePacks";

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/virtualenv/VirtualenvWrapper.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/virtualenv/VirtualenvWrapper.java
@@ -30,8 +30,8 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.python.ProcessWrapperException;
 import com.sap.psr.vulas.python.pip.PipInstalledPackage;
@@ -52,7 +52,7 @@ public class VirtualenvWrapper {
 	
 	private static final boolean IS_WIN = System.getProperty("os.name").contains("Windows");
 
-	private final static Log log = LogFactory.getLog(VirtualenvWrapper.class);
+	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(VirtualenvWrapper.class);
 
 	private Path pathToVirtualenvExecutable = null;
 
@@ -223,7 +223,7 @@ public class VirtualenvWrapper {
 	
 	private static class CopyFileVisitor extends SimpleFileVisitor<Path> {
 		
-		private final static Log log = LogFactory.getLog(CopyFileVisitor.class);
+		private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(CopyFileVisitor.class);
 		
 		private Path src = null;
 		private Path tgt = null;

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/virtualenv/VirtualenvWrapper.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/virtualenv/VirtualenvWrapper.java
@@ -52,7 +52,7 @@ public class VirtualenvWrapper {
 	
 	private static final boolean IS_WIN = System.getProperty("os.name").contains("Windows");
 
-	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(VirtualenvWrapper.class);
+	private final static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private Path pathToVirtualenvExecutable = null;
 
@@ -223,7 +223,7 @@ public class VirtualenvWrapper {
 	
 	private static class CopyFileVisitor extends SimpleFileVisitor<Path> {
 		
-		private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(CopyFileVisitor.class);
+		private final static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 		
 		private Path src = null;
 		private Path tgt = null;

--- a/lang/src/main/java/com/sap/psr/vulas/Construct.java
+++ b/lang/src/main/java/com/sap/psr/vulas/Construct.java
@@ -34,7 +34,7 @@ import com.sap.psr.vulas.shared.util.DigestUtil;
  */
 public class Construct {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(Construct.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	private ConstructId id = null;
 	private String content, contentDigest = null;
 	

--- a/lang/src/main/java/com/sap/psr/vulas/Construct.java
+++ b/lang/src/main/java/com/sap/psr/vulas/Construct.java
@@ -21,8 +21,8 @@ package com.sap.psr.vulas;
 
 import java.nio.charset.StandardCharsets;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.enums.DigestAlgorithm;
 import com.sap.psr.vulas.shared.json.JsonBuilder;
@@ -34,7 +34,7 @@ import com.sap.psr.vulas.shared.util.DigestUtil;
  */
 public class Construct {
 	
-	private static final Log log = LogFactory.getLog(Construct.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(Construct.class);
 	private ConstructId id = null;
 	private String content, contentDigest = null;
 	

--- a/lang/src/main/java/com/sap/psr/vulas/DirAnalyzer.java
+++ b/lang/src/main/java/com/sap/psr/vulas/DirAnalyzer.java
@@ -31,8 +31,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.util.DirUtil;
 import com.sap.psr.vulas.shared.util.FileSearch;
@@ -45,7 +45,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class DirAnalyzer implements FileAnalyzer {
 
-	private static final Log log = LogFactory.getLog(DirAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DirAnalyzer.class);
 
 	/** The dir to be analyzed. */
 	private File dir = null;

--- a/lang/src/main/java/com/sap/psr/vulas/DirAnalyzer.java
+++ b/lang/src/main/java/com/sap/psr/vulas/DirAnalyzer.java
@@ -45,7 +45,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class DirAnalyzer implements FileAnalyzer {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DirAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/** The dir to be analyzed. */
 	private File dir = null;

--- a/lang/src/main/java/com/sap/psr/vulas/FileAnalyzerFactory.java
+++ b/lang/src/main/java/com/sap/psr/vulas/FileAnalyzerFactory.java
@@ -26,8 +26,8 @@ import java.util.HashSet;
 import java.util.ServiceLoader;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.util.FileUtil;
 
@@ -36,7 +36,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
  */
 public class FileAnalyzerFactory {
 
-	private static final Log log = LogFactory.getLog(FileAnalyzerFactory.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(FileAnalyzerFactory.class);
 
 	private static String[] supportedFileExtensions = null;
 

--- a/lang/src/main/java/com/sap/psr/vulas/FileAnalyzerFactory.java
+++ b/lang/src/main/java/com/sap/psr/vulas/FileAnalyzerFactory.java
@@ -36,7 +36,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
  */
 public class FileAnalyzerFactory {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(FileAnalyzerFactory.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private static String[] supportedFileExtensions = null;
 

--- a/lang/src/main/java/com/sap/psr/vulas/backend/BackendConnector.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/BackendConnector.java
@@ -36,8 +36,8 @@ import java.util.regex.Pattern;
 
 import javax.validation.constraints.NotNull;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.apache.http.HttpStatus;
 
 import com.sap.psr.vulas.backend.requests.BasicHttpRequest;
@@ -77,7 +77,7 @@ import com.sap.psr.vulas.shared.util.StringList.ComparisonMode;
  */
 public class BackendConnector {
 
-	private static final Log log = LogFactory.getLog(BackendConnector.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BackendConnector.class);
 
 	/* Singleton instance. */
 	private static BackendConnector instance = null;

--- a/lang/src/main/java/com/sap/psr/vulas/backend/BackendConnector.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/BackendConnector.java
@@ -77,7 +77,7 @@ import com.sap.psr.vulas.shared.util.StringList.ComparisonMode;
  */
 public class BackendConnector {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BackendConnector.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/* Singleton instance. */
 	private static BackendConnector instance = null;

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/AbstractHttpRequest.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/AbstractHttpRequest.java
@@ -40,7 +40,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public abstract class AbstractHttpRequest implements HttpRequest {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AbstractHttpRequest.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	protected long ms = -1;
 

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/AbstractHttpRequest.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/AbstractHttpRequest.java
@@ -27,8 +27,8 @@ import java.io.ObjectOutputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.goals.GoalContext;
@@ -40,7 +40,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public abstract class AbstractHttpRequest implements HttpRequest {
 
-	private static final Log log = LogFactory.getLog(AbstractHttpRequest.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AbstractHttpRequest.class);
 
 	protected long ms = -1;
 

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/BasicHttpRequest.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/BasicHttpRequest.java
@@ -35,8 +35,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.apache.http.Header;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -63,7 +63,7 @@ import com.sap.psr.vulas.shared.util.StringUtil;
  */
 public class BasicHttpRequest extends AbstractHttpRequest {
 
-	private static final Log log = LogFactory.getLog(BasicHttpRequest.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BasicHttpRequest.class);
 	
 	private static final long serialVersionUID = 1L;
 

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/BasicHttpRequest.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/BasicHttpRequest.java
@@ -63,7 +63,7 @@ import com.sap.psr.vulas.shared.util.StringUtil;
  */
 public class BasicHttpRequest extends AbstractHttpRequest {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BasicHttpRequest.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private static final long serialVersionUID = 1L;
 

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/ConditionalHttpRequest.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/ConditionalHttpRequest.java
@@ -41,7 +41,7 @@ import com.sap.psr.vulas.goals.GoalContext;
  */
 public class ConditionalHttpRequest extends BasicHttpRequest {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ConditionalHttpRequest.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private List<ResponseCondition> conditions = new LinkedList<ResponseCondition>();
 

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/ConditionalHttpRequest.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/ConditionalHttpRequest.java
@@ -26,8 +26,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnectionException;
 import com.sap.psr.vulas.backend.HttpMethod;
@@ -41,7 +41,7 @@ import com.sap.psr.vulas.goals.GoalContext;
  */
 public class ConditionalHttpRequest extends BasicHttpRequest {
 
-	private static final Log log = LogFactory.getLog(ConditionalHttpRequest.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ConditionalHttpRequest.class);
 
 	private List<ResponseCondition> conditions = new LinkedList<ResponseCondition>();
 

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/HttpRequestList.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/HttpRequestList.java
@@ -37,7 +37,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class HttpRequestList extends AbstractHttpRequest {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(HttpRequestList.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * When set to true, the sending of requests will be stopped upon success, i.e., once a Http response code 2xx will be received.

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/HttpRequestList.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/HttpRequestList.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnectionException;
 import com.sap.psr.vulas.backend.HttpResponse;
@@ -37,7 +37,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class HttpRequestList extends AbstractHttpRequest {
 	
-	private static final Log log = LogFactory.getLog(HttpRequestList.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(HttpRequestList.class);
 
 	/**
 	 * When set to true, the sending of requests will be stopped upon success, i.e., once a Http response code 2xx will be received.

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/RequestRepeater.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/RequestRepeater.java
@@ -30,7 +30,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class RequestRepeater {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(RequestRepeater.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private long failCount = 0;
 	private long max = 50;

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/RequestRepeater.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/RequestRepeater.java
@@ -19,8 +19,8 @@
  */
 package com.sap.psr.vulas.backend.requests;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.shared.util.VulasConfiguration;
@@ -30,7 +30,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class RequestRepeater {
 
-	private static final Log log = LogFactory.getLog(RequestRepeater.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(RequestRepeater.class);
 
 	private long failCount = 0;
 	private long max = 50;

--- a/lang/src/main/java/com/sap/psr/vulas/core/util/CoreConfiguration.java
+++ b/lang/src/main/java/com/sap/psr/vulas/core/util/CoreConfiguration.java
@@ -23,8 +23,8 @@ import java.util.ServiceLoader;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnectionException;
 import com.sap.psr.vulas.backend.BackendConnector;
@@ -41,7 +41,7 @@ import com.sap.psr.vulas.sign.SignatureFactory;
  */
 public class CoreConfiguration {
 
-	private static final Log log = LogFactory.getLog(CoreConfiguration.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CoreConfiguration.class);
 
 	// Goal context
 	/** Constant <code>TENANT_TOKEN="vulas.core.tenant.token"</code> */

--- a/lang/src/main/java/com/sap/psr/vulas/core/util/CoreConfiguration.java
+++ b/lang/src/main/java/com/sap/psr/vulas/core/util/CoreConfiguration.java
@@ -41,7 +41,7 @@ import com.sap.psr.vulas.sign.SignatureFactory;
  */
 public class CoreConfiguration {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CoreConfiguration.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	// Goal context
 	/** Constant <code>TENANT_TOKEN="vulas.core.tenant.token"</code> */

--- a/lang/src/main/java/com/sap/psr/vulas/goals/AbstractAppGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/AbstractAppGoal.java
@@ -43,7 +43,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
  */
 public abstract class AbstractAppGoal extends AbstractGoal {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AbstractAppGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	/**
 	 * Maps file system paths to {@link Dependency}s.

--- a/lang/src/main/java/com/sap/psr/vulas/goals/AbstractAppGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/AbstractAppGoal.java
@@ -26,8 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnectionException;
 import com.sap.psr.vulas.backend.BackendConnector;
@@ -43,7 +43,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
  */
 public abstract class AbstractAppGoal extends AbstractGoal {
 
-	private static final Log log = LogFactory.getLog(AbstractAppGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AbstractAppGoal.class);
 	
 	/**
 	 * Maps file system paths to {@link Dependency}s.

--- a/lang/src/main/java/com/sap/psr/vulas/goals/AbstractGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/AbstractGoal.java
@@ -61,7 +61,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public abstract class AbstractGoal implements Runnable {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AbstractGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/** Constant <code>CLASS_EXT</code> */
 	protected static final String[] CLASS_EXT   = new String[] {"CLASS"};

--- a/lang/src/main/java/com/sap/psr/vulas/goals/AbstractGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/AbstractGoal.java
@@ -25,8 +25,8 @@ import java.util.Map;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnector;
 import com.sap.psr.vulas.core.util.CoreConfiguration;
@@ -61,7 +61,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public abstract class AbstractGoal implements Runnable {
 
-	private static final Log log = LogFactory.getLog(AbstractGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AbstractGoal.class);
 
 	/** Constant <code>CLASS_EXT</code> */
 	protected static final String[] CLASS_EXT   = new String[] {"CLASS"};

--- a/lang/src/main/java/com/sap/psr/vulas/goals/AbstractSpaceGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/AbstractSpaceGoal.java
@@ -23,8 +23,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.shared.enums.ExportConfiguration;
@@ -37,7 +37,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public abstract class AbstractSpaceGoal extends AbstractGoal {
 
-	private static final Log log = LogFactory.getLog(AbstractSpaceGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AbstractSpaceGoal.class);
 
 	/**
 	 * <p>Constructor for AbstractSpaceGoal.</p>

--- a/lang/src/main/java/com/sap/psr/vulas/goals/AbstractSpaceGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/AbstractSpaceGoal.java
@@ -37,7 +37,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public abstract class AbstractSpaceGoal extends AbstractGoal {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AbstractSpaceGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * <p>Constructor for AbstractSpaceGoal.</p>

--- a/lang/src/main/java/com/sap/psr/vulas/goals/BomGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/BomGoal.java
@@ -48,7 +48,7 @@ import com.sap.psr.vulas.tasks.BomTask;
  */
 public class BomGoal extends AbstractAppGoal {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BomGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * <p>Constructor for BomGoal.</p>

--- a/lang/src/main/java/com/sap/psr/vulas/goals/BomGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/BomGoal.java
@@ -27,8 +27,8 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnector;
 import com.sap.psr.vulas.core.util.CoreConfiguration;
@@ -48,7 +48,7 @@ import com.sap.psr.vulas.tasks.BomTask;
  */
 public class BomGoal extends AbstractAppGoal {
 
-	private static final Log log = LogFactory.getLog(BomGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BomGoal.class);
 
 	/**
 	 * <p>Constructor for BomGoal.</p>

--- a/lang/src/main/java/com/sap/psr/vulas/goals/CheckverGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/CheckverGoal.java
@@ -27,8 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.enums.GoalType;
 import com.sap.psr.vulas.shared.util.StringList;
@@ -40,7 +40,7 @@ import com.sap.psr.vulas.sign.SignatureAnalysis;
  */
 public class CheckverGoal extends AbstractAppGoal {
 	
-	private static final Log log = LogFactory.getLog(CheckverGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CheckverGoal.class);
 	
 	private StringList bugsWhitelist = new StringList();
 

--- a/lang/src/main/java/com/sap/psr/vulas/goals/CheckverGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/CheckverGoal.java
@@ -40,7 +40,7 @@ import com.sap.psr.vulas.sign.SignatureAnalysis;
  */
 public class CheckverGoal extends AbstractAppGoal {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CheckverGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private StringList bugsWhitelist = new StringList();
 

--- a/lang/src/main/java/com/sap/psr/vulas/goals/CleanGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/CleanGoal.java
@@ -19,8 +19,8 @@
  */
 package com.sap.psr.vulas.goals;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnector;
 import com.sap.psr.vulas.core.util.CoreConfiguration;
@@ -33,7 +33,7 @@ import com.sap.psr.vulas.shared.json.model.Application;
  */
 public class CleanGoal extends AbstractAppGoal {
 
-	private static final Log log = LogFactory.getLog(CleanGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CleanGoal.class);
 
 	/**
 	 * <p>Constructor for CleanGoal.</p>

--- a/lang/src/main/java/com/sap/psr/vulas/goals/CleanGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/CleanGoal.java
@@ -33,7 +33,7 @@ import com.sap.psr.vulas.shared.json.model.Application;
  */
 public class CleanGoal extends AbstractAppGoal {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CleanGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * <p>Constructor for CleanGoal.</p>

--- a/lang/src/main/java/com/sap/psr/vulas/goals/GoalExecutor.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/GoalExecutor.java
@@ -31,7 +31,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class GoalExecutor {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(GoalExecutor.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private static GoalExecutor instance = null;
 	

--- a/lang/src/main/java/com/sap/psr/vulas/goals/GoalExecutor.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/GoalExecutor.java
@@ -22,8 +22,8 @@ package com.sap.psr.vulas.goals;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 /**
  * <p>GoalExecutor class.</p>
@@ -31,7 +31,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class GoalExecutor {
 
-	private static final Log log = LogFactory.getLog(GoalExecutor.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(GoalExecutor.class);
 	
 	private static GoalExecutor instance = null;
 	

--- a/lang/src/main/java/com/sap/psr/vulas/goals/SequenceGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/SequenceGoal.java
@@ -24,8 +24,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.shared.enums.GoalType;
@@ -37,7 +37,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class SequenceGoal extends AbstractAppGoal {
 
-	private static final Log log = LogFactory.getLog(SequenceGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SequenceGoal.class);
 
 	private List<AbstractGoal> sequence = new ArrayList<AbstractGoal>();
 	

--- a/lang/src/main/java/com/sap/psr/vulas/goals/SequenceGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/SequenceGoal.java
@@ -37,7 +37,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class SequenceGoal extends AbstractAppGoal {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SequenceGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private List<AbstractGoal> sequence = new ArrayList<AbstractGoal>();
 	

--- a/lang/src/main/java/com/sap/psr/vulas/goals/SpaceCleanGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/SpaceCleanGoal.java
@@ -32,7 +32,7 @@ import com.sap.psr.vulas.shared.json.model.Space;
  */
 public class SpaceCleanGoal extends AbstractSpaceGoal {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SpaceCleanGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * <p>Constructor for SpaceCleanGoal.</p>

--- a/lang/src/main/java/com/sap/psr/vulas/goals/SpaceCleanGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/SpaceCleanGoal.java
@@ -19,8 +19,8 @@
  */
 package com.sap.psr.vulas.goals;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnector;
 import com.sap.psr.vulas.shared.enums.GoalType;
@@ -32,7 +32,7 @@ import com.sap.psr.vulas.shared.json.model.Space;
  */
 public class SpaceCleanGoal extends AbstractSpaceGoal {
 	
-	private static final Log log = LogFactory.getLog(SpaceCleanGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SpaceCleanGoal.class);
 
 	/**
 	 * <p>Constructor for SpaceCleanGoal.</p>

--- a/lang/src/main/java/com/sap/psr/vulas/goals/SpaceDelGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/SpaceDelGoal.java
@@ -19,8 +19,8 @@
  */
 package com.sap.psr.vulas.goals;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnector;
 import com.sap.psr.vulas.shared.enums.GoalType;
@@ -32,7 +32,7 @@ import com.sap.psr.vulas.shared.json.model.Space;
  */
 public class SpaceDelGoal extends AbstractSpaceGoal {
 	
-	private static final Log log = LogFactory.getLog(SpaceDelGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SpaceDelGoal.class);
 
 	/**
 	 * <p>Constructor for SpaceDelGoal.</p>

--- a/lang/src/main/java/com/sap/psr/vulas/goals/SpaceDelGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/SpaceDelGoal.java
@@ -32,7 +32,7 @@ import com.sap.psr.vulas.shared.json.model.Space;
  */
 public class SpaceDelGoal extends AbstractSpaceGoal {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SpaceDelGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * <p>Constructor for SpaceDelGoal.</p>

--- a/lang/src/main/java/com/sap/psr/vulas/goals/SpaceModGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/SpaceModGoal.java
@@ -19,8 +19,8 @@
  */
 package com.sap.psr.vulas.goals;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnector;
 import com.sap.psr.vulas.shared.enums.GoalType;
@@ -32,7 +32,7 @@ import com.sap.psr.vulas.shared.json.model.Space;
  */
 public class SpaceModGoal extends AbstractSpaceGoal {
 
-	private static final Log log = LogFactory.getLog(SpaceModGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SpaceModGoal.class);
 
 	/**
 	 * <p>Constructor for SpaceModGoal.</p>

--- a/lang/src/main/java/com/sap/psr/vulas/goals/SpaceModGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/SpaceModGoal.java
@@ -32,7 +32,7 @@ import com.sap.psr.vulas.shared.json.model.Space;
  */
 public class SpaceModGoal extends AbstractSpaceGoal {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SpaceModGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * <p>Constructor for SpaceModGoal.</p>

--- a/lang/src/main/java/com/sap/psr/vulas/goals/SpaceNewGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/SpaceNewGoal.java
@@ -22,8 +22,8 @@ package com.sap.psr.vulas.goals;
 import java.util.Arrays;
 import java.util.HashSet;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnector;
 import com.sap.psr.vulas.core.util.CoreConfiguration;
@@ -37,7 +37,7 @@ import com.sap.psr.vulas.shared.json.model.Space;
  */
 public class SpaceNewGoal extends AbstractSpaceGoal {
 	
-	private static final Log log = LogFactory.getLog(SpaceNewGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SpaceNewGoal.class);
 	
 	private Space createdSpace = null;
 

--- a/lang/src/main/java/com/sap/psr/vulas/goals/SpaceNewGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/SpaceNewGoal.java
@@ -37,7 +37,7 @@ import com.sap.psr.vulas.shared.json.model.Space;
  */
 public class SpaceNewGoal extends AbstractSpaceGoal {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SpaceNewGoal.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private Space createdSpace = null;
 

--- a/lang/src/main/java/com/sap/psr/vulas/malice/ZipSlipAnalyzer.java
+++ b/lang/src/main/java/com/sap/psr/vulas/malice/ZipSlipAnalyzer.java
@@ -50,7 +50,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class ZipSlipAnalyzer implements MaliciousnessAnalyzer {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ZipSlipAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private Path destinationPath = VulasConfiguration.getGlobal().getTmpDir().toAbsolutePath().resolve(StringUtil.getRandonString(10));
 

--- a/lang/src/main/java/com/sap/psr/vulas/malice/ZipSlipAnalyzer.java
+++ b/lang/src/main/java/com/sap/psr/vulas/malice/ZipSlipAnalyzer.java
@@ -33,8 +33,8 @@ import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.util.DirUtil;
 import com.sap.psr.vulas.shared.util.StringUtil;
@@ -50,7 +50,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class ZipSlipAnalyzer implements MaliciousnessAnalyzer {
 
-	private static final Log log = LogFactory.getLog(ZipSlipAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ZipSlipAnalyzer.class);
 
 	private Path destinationPath = VulasConfiguration.getGlobal().getTmpDir().toAbsolutePath().resolve(StringUtil.getRandonString(10));
 

--- a/lang/src/main/java/com/sap/psr/vulas/report/Report.java
+++ b/lang/src/main/java/com/sap/psr/vulas/report/Report.java
@@ -69,7 +69,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class Report {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(Report.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private final SimpleDateFormat dateFormat = new SimpleDateFormat("dd.MM.yyy HH:mm Z");
 

--- a/lang/src/main/java/com/sap/psr/vulas/report/Report.java
+++ b/lang/src/main/java/com/sap/psr/vulas/report/Report.java
@@ -36,8 +36,8 @@ import java.util.TreeSet;
 
 import javax.validation.constraints.NotNull;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
@@ -69,7 +69,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class Report {
 
-	private static final Log log = LogFactory.getLog(Report.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(Report.class);
 
 	private final SimpleDateFormat dateFormat = new SimpleDateFormat("dd.MM.yyy HH:mm Z");
 

--- a/lang/src/main/java/com/sap/psr/vulas/sign/SignatureAnalysis.java
+++ b/lang/src/main/java/com/sap/psr/vulas/sign/SignatureAnalysis.java
@@ -35,7 +35,7 @@ import com.sap.psr.vulas.shared.util.StringList;
  * <p>SignatureAnalysis class.</p>
  */
 public class SignatureAnalysis {
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SignatureAnalysis.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
     private Application app;
     
     private StringList bugs;

--- a/lang/src/main/java/com/sap/psr/vulas/sign/SignatureAnalysis.java
+++ b/lang/src/main/java/com/sap/psr/vulas/sign/SignatureAnalysis.java
@@ -24,8 +24,8 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.json.model.Application;
 import com.sap.psr.vulas.shared.util.FileSearch;
@@ -35,7 +35,7 @@ import com.sap.psr.vulas.shared.util.StringList;
  * <p>SignatureAnalysis class.</p>
  */
 public class SignatureAnalysis {
-    private static final Log log = LogFactory.getLog(SignatureAnalysis.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SignatureAnalysis.class);
     private Application app;
     
     private StringList bugs;

--- a/lang/src/main/java/com/sap/psr/vulas/tasks/AbstractTask.java
+++ b/lang/src/main/java/com/sap/psr/vulas/tasks/AbstractTask.java
@@ -38,7 +38,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public abstract class AbstractTask implements Task {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AbstractTask.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private GoalClient client = null;
 	

--- a/lang/src/main/java/com/sap/psr/vulas/tasks/AbstractTask.java
+++ b/lang/src/main/java/com/sap/psr/vulas/tasks/AbstractTask.java
@@ -23,8 +23,8 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.goals.GoalConfigurationException;
 import com.sap.psr.vulas.shared.enums.GoalClient;
@@ -38,7 +38,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public abstract class AbstractTask implements Task {
 	
-	private static final Log log = LogFactory.getLog(AbstractTask.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AbstractTask.class);
 
 	private GoalClient client = null;
 	

--- a/patch-analyzer/src/main/java/com/sap/psr/vulas/patcha/FileComparator.java
+++ b/patch-analyzer/src/main/java/com/sap/psr/vulas/patcha/FileComparator.java
@@ -41,7 +41,7 @@ import com.sap.psr.vulas.vcs.FileChange;
  */
 public class FileComparator {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(FileComparator.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	private File def, fix = null;
 
 	private FileAnalyzer defAnalyzer, fixAnalyzer = null;

--- a/patch-analyzer/src/main/java/com/sap/psr/vulas/patcha/FileComparator.java
+++ b/patch-analyzer/src/main/java/com/sap/psr/vulas/patcha/FileComparator.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.ConstructChange;
 import com.sap.psr.vulas.ConstructId;
@@ -41,7 +41,7 @@ import com.sap.psr.vulas.vcs.FileChange;
  */
 public class FileComparator {
 
-	private static final Log log = LogFactory.getLog(FileComparator.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(FileComparator.class);
 	private File def, fix = null;
 
 	private FileAnalyzer defAnalyzer, fixAnalyzer = null;

--- a/patch-analyzer/src/main/java/com/sap/psr/vulas/patcha/PatchAnalyzer.java
+++ b/patch-analyzer/src/main/java/com/sap/psr/vulas/patcha/PatchAnalyzer.java
@@ -68,7 +68,7 @@ import com.sap.psr.vulas.vcs.RepoMismatchException;
  */
 public class PatchAnalyzer {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PatchAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private String id = Double.toString(Math.random());
 	private String bugid = null;

--- a/patch-analyzer/src/main/java/com/sap/psr/vulas/patcha/PatchAnalyzer.java
+++ b/patch-analyzer/src/main/java/com/sap/psr/vulas/patcha/PatchAnalyzer.java
@@ -38,8 +38,8 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.Construct;
 import com.sap.psr.vulas.ConstructChange;
@@ -68,7 +68,7 @@ import com.sap.psr.vulas.vcs.RepoMismatchException;
  */
 public class PatchAnalyzer {
 
-	private static final Log log = LogFactory.getLog(PatchAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PatchAnalyzer.class);
 
 	private String id = Double.toString(Math.random());
 	private String bugid = null;

--- a/patch-analyzer/src/main/java/com/sap/psr/vulas/patcha/VulasProxySelector.java
+++ b/patch-analyzer/src/main/java/com/sap/psr/vulas/patcha/VulasProxySelector.java
@@ -46,7 +46,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class VulasProxySelector extends ProxySelector {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(VulasProxySelector.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private static ProxySelector instance = new VulasProxySelector();
 

--- a/patch-analyzer/src/main/java/com/sap/psr/vulas/patcha/VulasProxySelector.java
+++ b/patch-analyzer/src/main/java/com/sap/psr/vulas/patcha/VulasProxySelector.java
@@ -32,8 +32,8 @@ import java.util.Set;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.util.StringList;
 import com.sap.psr.vulas.shared.util.StringList.CaseSensitivity;
@@ -46,7 +46,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class VulasProxySelector extends ProxySelector {
 
-	private static final Log log = LogFactory.getLog(VulasProxySelector.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(VulasProxySelector.class);
 
 	private static ProxySelector instance = new VulasProxySelector();
 

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/representation/ArtifactResult2.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/representation/ArtifactResult2.java
@@ -35,7 +35,7 @@ import com.sap.psr.vulas.shared.json.model.Version;
      * class containing the results on a single archive.
      */
     public class ArtifactResult2 implements Comparable<ArtifactResult2> {
-    	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ArtifactResult2.class);
+    	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
     
     String group, artifact;
     

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/representation/ArtifactResult2.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/representation/ArtifactResult2.java
@@ -22,8 +22,8 @@ package com.sap.psr.vulas.patcheval.representation;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.enums.ConstructChangeType;
 import com.sap.psr.vulas.shared.json.model.AffectedConstructChange;
@@ -35,7 +35,7 @@ import com.sap.psr.vulas.shared.json.model.Version;
      * class containing the results on a single archive.
      */
     public class ArtifactResult2 implements Comparable<ArtifactResult2> {
-    	private static final Log log = LogFactory.getLog(ArtifactResult2.class);
+    	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ArtifactResult2.class);
     
     String group, artifact;
     

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/representation/ConstructPathAssessment2.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/representation/ConstructPathAssessment2.java
@@ -22,8 +22,8 @@ package com.sap.psr.vulas.patcheval.representation;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.patcheval2.BugLibManager;
 import com.sap.psr.vulas.shared.enums.ConstructType;

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/representation/OrderedCCperConstructPath2.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/representation/OrderedCCperConstructPath2.java
@@ -40,7 +40,7 @@ import com.sap.psr.vulas.shared.json.model.ConstructId;
  */
 public class OrderedCCperConstructPath2{
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(OrderedCCperConstructPath2.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
     private ConstructId constructId;
     private String repoPath;

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/representation/OrderedCCperConstructPath2.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/representation/OrderedCCperConstructPath2.java
@@ -27,8 +27,8 @@ package com.sap.psr.vulas.patcheval.representation;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.enums.ConstructChangeType;
 import com.sap.psr.vulas.shared.json.model.ConstructChange;
@@ -40,7 +40,7 @@ import com.sap.psr.vulas.shared.json.model.ConstructId;
  */
 public class OrderedCCperConstructPath2{
 	
-	private static final Log log = LogFactory.getLog(OrderedCCperConstructPath2.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(OrderedCCperConstructPath2.class);
 	
     private ConstructId constructId;
     private String repoPath;

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/representation/ReleaseTree.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/representation/ReleaseTree.java
@@ -23,8 +23,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 /**
  * This class holds all artifact results for the same minor release, e.g., possible roots are 1.0.0, 1.1.0,.. ,2.3.0,..
@@ -32,7 +32,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class ReleaseTree {
 	
-	private static final Log log = LogFactory.getLog(ReleaseTree.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ReleaseTree.class);
 	
 	ReleaseTree maintenance;
 	ReleaseTree build;

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/representation/ReleaseTree.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/representation/ReleaseTree.java
@@ -32,7 +32,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class ReleaseTree {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ReleaseTree.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	ReleaseTree maintenance;
 	ReleaseTree build;

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/utils/CSVHelper2.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/utils/CSVHelper2.java
@@ -43,14 +43,14 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Random;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 /**
  * Helper class for writing results to file.
  */
 public class CSVHelper2 {
-    private static final Log log = LogFactory.getLog(CSVHelper2.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CSVHelper2.class);
 
     static String COMMA_DELIMITER = ";";
     static String NEW_LINE_SEPARATOR = "\n";

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/utils/CSVHelper2.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/utils/CSVHelper2.java
@@ -50,7 +50,7 @@ import org.apache.logging.log4j.Logger;
  * Helper class for writing results to file.
  */
 public class CSVHelper2 {
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CSVHelper2.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
     static String COMMA_DELIMITER = ";";
     static String NEW_LINE_SEPARATOR = "\n";

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BugLibAnalyzer.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BugLibAnalyzer.java
@@ -70,7 +70,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  * Given a bug, this class analyzes all versions (retrieved from Maven central) of JARs containing vulnerable code produces a csv file.
  */
 public class BugLibAnalyzer {
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BugLibAnalyzer.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
     
     private Bug bug;
     private ExecutorService executorService = null ;

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BugLibAnalyzer.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BugLibAnalyzer.java
@@ -43,8 +43,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnectionException;
 import com.sap.psr.vulas.backend.BackendConnector;
@@ -70,7 +70,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  * Given a bug, this class analyzes all versions (retrieved from Maven central) of JARs containing vulnerable code produces a csv file.
  */
 public class BugLibAnalyzer {
-    private static final Log log = LogFactory.getLog(BugLibAnalyzer.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BugLibAnalyzer.class);
     
     private Bug bug;
     private ExecutorService executorService = null ;

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BugLibManager.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BugLibManager.java
@@ -42,8 +42,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -81,7 +81,7 @@ public class BugLibManager {
 	
 
 	
-	private static final Log log = LogFactory.getLog(BugLibManager.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BugLibManager.class);
 
 	// used to serialize cc
 	Bug bugChangeList = null; 

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BugLibManager.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BugLibManager.java
@@ -81,7 +81,7 @@ public class BugLibManager {
 	
 
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BugLibManager.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	// used to serialize cc
 	Bug bugChangeList = null; 

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/ByteCodeComparator.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/ByteCodeComparator.java
@@ -49,7 +49,7 @@ import com.sap.psr.vulas.java.sign.ASTSignatureChange;
  */
 public class ByteCodeComparator implements Runnable{ 
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ByteCodeComparator.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	
 	private final ArtifactResult2 ar;

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/ByteCodeComparator.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/ByteCodeComparator.java
@@ -24,8 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.google.gson.Gson;
@@ -49,7 +49,7 @@ import com.sap.psr.vulas.java.sign.ASTSignatureChange;
  */
 public class ByteCodeComparator implements Runnable{ 
 
-	private static final Log log = LogFactory.getLog(ByteCodeComparator.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ByteCodeComparator.class);
 	
 	
 	private final ArtifactResult2 ar;

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BytecodeAnalyzer.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BytecodeAnalyzer.java
@@ -54,7 +54,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class BytecodeAnalyzer {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BytecodeAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	String digest;
 

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BytecodeAnalyzer.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BytecodeAnalyzer.java
@@ -33,8 +33,8 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.BackendConnectionException;
 import com.sap.psr.vulas.backend.BackendConnector;
@@ -54,7 +54,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class BytecodeAnalyzer {
 	
-	private static final Log log = LogFactory.getLog(BytecodeAnalyzer.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BytecodeAnalyzer.class);
 	
 	String digest;
 

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/LibraryAnalyzerThread2.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/LibraryAnalyzerThread2.java
@@ -56,7 +56,7 @@ import org.apache.logging.log4j.Logger;
  * Thread to analyze for the set of received libraries using CIA service.
  */
 public class LibraryAnalyzerThread2 implements Callable<List<ConstructPathLibResult2>>{
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(LibraryAnalyzerThread2.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
     private int tid;
     
     Map<Class<?>,StdDeserializer<?>> custom_deserializers = new HashMap<Class<?>,StdDeserializer<?>>();

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/LibraryAnalyzerThread2.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/LibraryAnalyzerThread2.java
@@ -49,14 +49,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 /**
  * Thread to analyze for the set of received libraries using CIA service.
  */
 public class LibraryAnalyzerThread2 implements Callable<List<ConstructPathLibResult2>>{
-    private static final Log log = LogFactory.getLog(LibraryAnalyzerThread2.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(LibraryAnalyzerThread2.class);
     private int tid;
     
     Map<Class<?>,StdDeserializer<?>> custom_deserializers = new HashMap<Class<?>,StdDeserializer<?>>();

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/Main.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/Main.java
@@ -29,8 +29,8 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.patcheval.utils.PEConfiguration;
 import com.sap.psr.vulas.shared.util.VulasConfiguration;
@@ -41,7 +41,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class Main {
 
-	private static final Log log = LogFactory.getLog(Main.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(Main.class);
 
 
 	/**

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/Main.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/Main.java
@@ -41,7 +41,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class Main {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(Main.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 
 	/**

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/PE_Run.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/PE_Run.java
@@ -26,8 +26,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.google.gson.Gson;
 import com.sap.psr.vulas.backend.BackendConnectionException;
@@ -47,7 +47,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class PE_Run implements Runnable {
 
-	private static final Log log = LogFactory.getLog(PE_Run.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PE_Run.class);
 
 	/**
 	 * <p>run.</p>

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/PE_Run.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/PE_Run.java
@@ -47,7 +47,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
  */
 public class PE_Run implements Runnable {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(PE_Run.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * <p>run.</p>

--- a/pom.xml
+++ b/pom.xml
@@ -252,15 +252,16 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
-			<version>1.2</version>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.13.3</version>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.13.3</version>
 		</dependency>
+		
 	</dependencies>
 
 	<!-- Use the same versions across all child projects -->

--- a/repo-client/src/main/java/com/sap/psr/vulas/git/GitClient.java
+++ b/repo-client/src/main/java/com/sap/psr/vulas/git/GitClient.java
@@ -36,8 +36,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.NoHeadException;
@@ -75,7 +75,7 @@ import com.sap.psr.vulas.vcs.RepoMismatchException;
 public class GitClient implements IVCSClient {
 
 	private static final int RANDOM_ID_LENGTH = 8;
-	private static final Log log = LogFactory.getLog( GitClient.class );
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger( GitClient.class );
 	private static final String TYPE = "GIT";
 
 	private String id;

--- a/repo-client/src/main/java/com/sap/psr/vulas/svn/SvnClient.java
+++ b/repo-client/src/main/java/com/sap/psr/vulas/svn/SvnClient.java
@@ -65,7 +65,7 @@ import com.sap.psr.vulas.vcs.RepoMismatchException;
 
 public class SvnClient implements IVCSClient {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SvnClient.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private static final String TYPE = "SVN";
 

--- a/repo-client/src/main/java/com/sap/psr/vulas/svn/SvnClient.java
+++ b/repo-client/src/main/java/com/sap/psr/vulas/svn/SvnClient.java
@@ -35,8 +35,8 @@ import java.util.Set;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 import org.tmatesoft.svn.core.SVNDepth;
 import org.tmatesoft.svn.core.SVNDirEntry;
 import org.tmatesoft.svn.core.SVNException;
@@ -65,7 +65,7 @@ import com.sap.psr.vulas.vcs.RepoMismatchException;
 
 public class SvnClient implements IVCSClient {
 
-	private static final Log log = LogFactory.getLog(SvnClient.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SvnClient.class);
 
 	private static final String TYPE = "SVN";
 

--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -277,6 +277,18 @@
 				<version>8.5.57</version>
 			</dependency>
 			
+			<!--  Fix dependency on vulnerable versions of log4j2 -->
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-api</artifactId>
+				<version>2.13.3</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-core</artifactId>
+				<version>2.13.3</version>
+			</dependency>
+			
 		</dependencies>
 	</dependencyManagement>
 

--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -166,12 +166,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-mock</artifactId>
-			<version>2.0.8</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-all</artifactId>
 			<version>1.3</version>

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/DependencyUtil.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/DependencyUtil.java
@@ -39,7 +39,7 @@ import com.sap.psr.vulas.backend.model.Library;
 public class DependencyUtil {
 	
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DependencyUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	/**
 	 * Returns a set of dependencies such that every {@link Dependency} points to a different {@link Library}.

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/DependencyUtil.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/DependencyUtil.java
@@ -24,8 +24,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.backend.model.Application;
 import com.sap.psr.vulas.backend.model.Dependency;
@@ -39,7 +39,7 @@ import com.sap.psr.vulas.backend.model.Library;
 public class DependencyUtil {
 	
 
-	private static final Log log = LogFactory.getLog(DependencyUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DependencyUtil.class);
 	
 	/**
 	 * Returns a set of dependencies such that every {@link Dependency} points to a different {@link Library}.

--- a/rest-lib-utils/pom.xml
+++ b/rest-lib-utils/pom.xml
@@ -195,15 +195,16 @@
 			<version>27.1-jre</version>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
 			<version>1.2</version> <!-- 1.1.3 in the original dep-finder -->
 		</dependency>
+		<!-- New logging impl will be used in the context of Spring Boot -->
+		<!-- dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>1.2.17</version>
+		</dependency-->
 		<dependency>
 			<groupId>ant</groupId>
 			<artifactId>ant</artifactId>
@@ -279,6 +280,18 @@
 				<groupId>org.apache.tomcat.embed</groupId>
 				<artifactId>tomcat-embed-websocket</artifactId>
 				<version>8.5.57</version>
+			</dependency>
+			
+			<!--  Fix dependency on vulnerable versions of log4j2 -->
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-api</artifactId>
+				<version>2.13.3</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-core</artifactId>
+				<version>2.13.3</version>
 			</dependency>
 
 		</dependencies>

--- a/shared/src/main/java/com/sap/psr/vulas/shared/cache/Cache.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/cache/Cache.java
@@ -35,7 +35,7 @@ import com.sap.psr.vulas.shared.util.StopWatch;
  */
 public class Cache<S, T> {
 	
-	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(Cache.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private long refreshMilli = -1;
 	private int maxSize = -1;

--- a/shared/src/main/java/com/sap/psr/vulas/shared/cache/Cache.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/cache/Cache.java
@@ -23,8 +23,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
 
 import com.sap.psr.vulas.shared.util.StopWatch;
 
@@ -36,7 +35,7 @@ import com.sap.psr.vulas.shared.util.StopWatch;
  */
 public class Cache<S, T> {
 	
-	private static final Log log = LogFactory.getLog(Cache.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(Cache.class);
 
 	private long refreshMilli = -1;
 	private int maxSize = -1;
@@ -89,6 +88,7 @@ public class Cache<S, T> {
 		this.reader = _reader;
 		this.refreshMilli = _refresh_min * MILLI_IN_MIN;
 		this.maxSize = _max_size;
+		
 	}
 	
 	/**

--- a/shared/src/main/java/com/sap/psr/vulas/shared/enums/ExportFormat.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/enums/ExportFormat.java
@@ -21,8 +21,8 @@ package com.sap.psr.vulas.shared.enums;
 
 import javax.validation.constraints.NotNull;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.json.model.Application;
 
@@ -34,7 +34,7 @@ public enum ExportFormat {
 	CSV, JSON;
 
 	/** Constant <code>log</code> */
-	private static Log log = LogFactory.getLog(ExportFormat.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(ExportFormat.class);
 	
 	/** Constant <code>TXT_CSV="text/csv;charset=UTF-8"</code> */
 	public static final String TXT_CSV   = "text/csv;charset=UTF-8";

--- a/shared/src/main/java/com/sap/psr/vulas/shared/enums/ExportFormat.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/enums/ExportFormat.java
@@ -34,7 +34,7 @@ public enum ExportFormat {
 	CSV, JSON;
 
 	/** Constant <code>log</code> */
-	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(ExportFormat.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	/** Constant <code>TXT_CSV="text/csv;charset=UTF-8"</code> */
 	public static final String TXT_CSV   = "text/csv;charset=UTF-8";

--- a/shared/src/main/java/com/sap/psr/vulas/shared/enums/Scope.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/enums/Scope.java
@@ -34,7 +34,7 @@ public enum Scope {
 	COMPILE, PROVIDED, RUNTIME, TEST, SYSTEM, IMPORT;
 
 	/** Constant <code>log</code> */
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(Scope.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	/**
 	 * <p>fromStringArray.</p>

--- a/shared/src/main/java/com/sap/psr/vulas/shared/enums/Scope.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/enums/Scope.java
@@ -22,8 +22,8 @@ package com.sap.psr.vulas.shared.enums;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 
 
@@ -34,7 +34,7 @@ public enum Scope {
 	COMPILE, PROVIDED, RUNTIME, TEST, SYSTEM, IMPORT;
 
 	/** Constant <code>log</code> */
-	private static final Log log = LogFactory.getLog(Scope.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(Scope.class);
 	
 	/**
 	 * <p>fromStringArray.</p>

--- a/shared/src/main/java/com/sap/psr/vulas/shared/enums/VulnDepOrigin.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/enums/VulnDepOrigin.java
@@ -22,8 +22,8 @@ package com.sap.psr.vulas.shared.enums;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 
 
@@ -34,7 +34,7 @@ public enum VulnDepOrigin {
 	CC, BUNDLEDCC, AFFLIBID, BUNDLEDAFFLIBID;
 
 	/** Constant <code>log</code> */
-	private static final Log log = LogFactory.getLog(VulnDepOrigin.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(VulnDepOrigin.class);
 	
 	/**
 	 * <p>fromStringArray.</p>

--- a/shared/src/main/java/com/sap/psr/vulas/shared/enums/VulnDepOrigin.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/enums/VulnDepOrigin.java
@@ -34,7 +34,7 @@ public enum VulnDepOrigin {
 	CC, BUNDLEDCC, AFFLIBID, BUNDLEDAFFLIBID;
 
 	/** Constant <code>log</code> */
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(VulnDepOrigin.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	/**
 	 * <p>fromStringArray.</p>

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/JsonReader.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/JsonReader.java
@@ -34,7 +34,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
  */
 public class JsonReader<T> {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JsonReader.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private Class<T> clazz;
 	

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/JsonReader.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/JsonReader.java
@@ -22,8 +22,8 @@ package com.sap.psr.vulas.shared.json;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.util.FileUtil;
 
@@ -34,7 +34,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
  */
 public class JsonReader<T> {
 	
-	private static final Log log = LogFactory.getLog(JsonReader.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JsonReader.class);
 	
 	private Class<T> clazz;
 	

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/JsonWriter.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/JsonWriter.java
@@ -34,7 +34,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
  */
 public class JsonWriter<T> {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JsonWriter.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	/**
 	 * <p>write.</p>

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/JsonWriter.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/JsonWriter.java
@@ -22,8 +22,8 @@ package com.sap.psr.vulas.shared.json;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.util.FileUtil;
 
@@ -34,7 +34,7 @@ import com.sap.psr.vulas.shared.util.FileUtil;
  */
 public class JsonWriter<T> {
 
-	private static final Log log = LogFactory.getLog(JsonWriter.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(JsonWriter.class);
 	
 	/**
 	 * <p>write.</p>

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/Artifact.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/Artifact.java
@@ -24,8 +24,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.regex.Pattern;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -39,7 +39,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Artifact implements Serializable,Comparable<Object> {
 	
-	private static Log log = LogFactory.getLog(Artifact.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(Artifact.class);
 	
 	final static Pattern VERSION_PATTERN = Pattern.compile("([\\d\\.]*)(.*)", Pattern.DOTALL);
 	

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/Artifact.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/Artifact.java
@@ -39,7 +39,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Artifact implements Serializable,Comparable<Object> {
 	
-	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(Artifact.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	final static Pattern VERSION_PATTERN = Pattern.compile("([\\d\\.]*)(.*)", Pattern.DOTALL);
 	

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/ExemptionBug.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/ExemptionBug.java
@@ -43,7 +43,7 @@ import com.sap.psr.vulas.shared.enums.AffectedVersionSource;
  */
 public class ExemptionBug implements IExemption {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ExemptionBug.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private static final String ALL = "*";
 	

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/ExemptionBug.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/ExemptionBug.java
@@ -23,8 +23,8 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
@@ -43,7 +43,7 @@ import com.sap.psr.vulas.shared.enums.AffectedVersionSource;
  */
 public class ExemptionBug implements IExemption {
 	
-	private static final Log log = LogFactory.getLog(ExemptionBug.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ExemptionBug.class);
 	
 	private static final String ALL = "*";
 	

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/ExemptionUnassessed.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/ExemptionUnassessed.java
@@ -22,12 +22,12 @@ package com.sap.psr.vulas.shared.json.model;
 import java.util.Map;
 
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 public class ExemptionUnassessed implements IExemption {
 
-	private static final Log log = LogFactory.getLog(ExemptionUnassessed.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ExemptionUnassessed.class);
 
 	/**
 	 * Configuration setting <code>REP_EXCL_UNASS="vulas.report.exceptionExcludeUnassessed"</code>.

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/ExemptionUnassessed.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/ExemptionUnassessed.java
@@ -27,7 +27,7 @@ import org.apache.logging.log4j.Logger;
 
 public class ExemptionUnassessed implements IExemption {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ExemptionUnassessed.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * Configuration setting <code>REP_EXCL_UNASS="vulas.report.exceptionExcludeUnassessed"</code>.

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/LibraryId.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/LibraryId.java
@@ -23,8 +23,8 @@ import java.io.Serializable;
 
 import javax.validation.constraints.NotNull;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -41,7 +41,7 @@ public class LibraryId implements Serializable, Comparable<LibraryId> {
 
 	private static final long serialVersionUID = 1L;
 
-	private static Log log = LogFactory.getLog(LibraryId.class);	
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(LibraryId.class);	
 
 	@JsonIgnore
 	private Long id;

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/LibraryId.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/LibraryId.java
@@ -41,7 +41,7 @@ public class LibraryId implements Serializable, Comparable<LibraryId> {
 
 	private static final long serialVersionUID = 1L;
 
-	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(LibraryId.class);	
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger();	
 
 	@JsonIgnore
 	private Long id;

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/Version.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/Version.java
@@ -22,8 +22,8 @@ package com.sap.psr.vulas.shared.json.model;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 
 
@@ -33,7 +33,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class Version implements Comparable<Version>{
 
-	private static Log log = LogFactory.getLog(Version.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(Version.class);
 
 	final static Pattern VERSION_PATTERN = Pattern.compile("([\\d\\.]*)(.*)", Pattern.DOTALL);
 

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/Version.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/Version.java
@@ -33,7 +33,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class Version implements Comparable<Version>{
 
-	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(Version.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	final static Pattern VERSION_PATTERN = Pattern.compile("([\\d\\.]*)(.*)", Pattern.DOTALL);
 

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/mavenCentral/ResponseDoc.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/mavenCentral/ResponseDoc.java
@@ -42,7 +42,7 @@ public class ResponseDoc implements Comparable {
 	
 	final static Pattern VERSION_PATTERN = Pattern.compile("([\\d\\.]*)(.*)", Pattern.DOTALL);
 	
-	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(ResponseDoc.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private String id;
 	

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/mavenCentral/ResponseDoc.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/mavenCentral/ResponseDoc.java
@@ -23,8 +23,8 @@ import java.util.Collection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -42,7 +42,7 @@ public class ResponseDoc implements Comparable {
 	
 	final static Pattern VERSION_PATTERN = Pattern.compile("([\\d\\.]*)(.*)", Pattern.DOTALL);
 	
-	private static Log log = LogFactory.getLog(ResponseDoc.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(ResponseDoc.class);
 
 	private String id;
 	

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/AbstractFileSearch.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/AbstractFileSearch.java
@@ -30,8 +30,7 @@ import java.util.TreeSet;
 
 import javax.validation.constraints.NotNull;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>AbstractFileSearch class.</p>
@@ -39,10 +38,10 @@ import org.apache.commons.logging.LogFactory;
  */
 public class AbstractFileSearch extends SimpleFileVisitor<Path> {
 	
-	private static Log log = null;
-	private static final Log getLog() {
+	private static Logger log = null;
+	private static final Logger getLog() {
 		if(AbstractFileSearch.log==null)
-			AbstractFileSearch.log = LogFactory.getLog(AbstractFileSearch.class);
+			AbstractFileSearch.log = org.apache.logging.log4j.LogManager.getLogger(AbstractFileSearch.class);
 		return AbstractFileSearch.log;
 	}
 	

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/AbstractFileSearch.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/AbstractFileSearch.java
@@ -41,7 +41,7 @@ public class AbstractFileSearch extends SimpleFileVisitor<Path> {
 	private static Logger log = null;
 	private static final Logger getLog() {
 		if(AbstractFileSearch.log==null)
-			AbstractFileSearch.log = org.apache.logging.log4j.LogManager.getLogger(AbstractFileSearch.class);
+			AbstractFileSearch.log = org.apache.logging.log4j.LogManager.getLogger();
 		return AbstractFileSearch.log;
 	}
 	

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/ConstructIdUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/ConstructIdUtil.java
@@ -24,8 +24,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.json.model.ConstructId;
 
@@ -35,7 +35,7 @@ import com.sap.psr.vulas.shared.json.model.ConstructId;
  */
 public class ConstructIdUtil {
 
-	private static final Log log = LogFactory.getLog(ConstructIdUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ConstructIdUtil.class);
 	
 	/**
 	 * <p>filterWithRegex.</p>

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/ConstructIdUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/ConstructIdUtil.java
@@ -35,7 +35,7 @@ import com.sap.psr.vulas.shared.json.model.ConstructId;
  */
 public class ConstructIdUtil {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ConstructIdUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	/**
 	 * <p>filterWithRegex.</p>

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/DependencyUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/DependencyUtil.java
@@ -38,7 +38,7 @@ import com.sap.psr.vulas.shared.json.model.Library;
  */
 public class DependencyUtil {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DependencyUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	/**
 	 * Returns a set of dependencies such that every {@link Dependency} points to a different {@link Library}.

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/DependencyUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/DependencyUtil.java
@@ -25,8 +25,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.json.model.Application;
 import com.sap.psr.vulas.shared.json.model.Dependency;
@@ -38,7 +38,7 @@ import com.sap.psr.vulas.shared.json.model.Library;
  */
 public class DependencyUtil {
 
-	private static final Log log = LogFactory.getLog(DependencyUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DependencyUtil.class);
 	
 	/**
 	 * Returns a set of dependencies such that every {@link Dependency} points to a different {@link Library}.

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/DigestUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/DigestUtil.java
@@ -24,8 +24,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.enums.DigestAlgorithm;
 
@@ -34,7 +34,7 @@ import com.sap.psr.vulas.shared.enums.DigestAlgorithm;
  */
 public class DigestUtil {
 	
-	private static final Log log = LogFactory.getLog(DigestUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DigestUtil.class);
 	
 	private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 	

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/DigestUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/DigestUtil.java
@@ -34,7 +34,7 @@ import com.sap.psr.vulas.shared.enums.DigestAlgorithm;
  */
 public class DigestUtil {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DigestUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 	

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/DirUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/DirUtil.java
@@ -47,7 +47,7 @@ import com.sap.psr.vulas.shared.enums.DigestAlgorithm;
  */
 public class DirUtil {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DirUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * Returns true if the given directory contains a file with the given name, false otherwise.

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/DirUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/DirUtil.java
@@ -36,8 +36,8 @@ import java.util.jar.JarEntry;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.enums.DigestAlgorithm;
 
@@ -47,7 +47,7 @@ import com.sap.psr.vulas.shared.enums.DigestAlgorithm;
  */
 public class DirUtil {
 
-	private static final Log log = LogFactory.getLog(DirUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DirUtil.class);
 
 	/**
 	 * Returns true if the given directory contains a file with the given name, false otherwise.

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/DirWithFileSearch.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/DirWithFileSearch.java
@@ -35,15 +35,15 @@ import java.util.regex.Pattern;
 
 import javax.validation.constraints.NotNull;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 /**
  * Searches for all directories containing a file with a given name.
  */
 public class DirWithFileSearch extends AbstractFileSearch {
 
-	private static final Log log = LogFactory.getLog(DirWithFileSearch.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DirWithFileSearch.class);
 
 	private String filename = null;
 

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/DirWithFileSearch.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/DirWithFileSearch.java
@@ -43,7 +43,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class DirWithFileSearch extends AbstractFileSearch {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DirWithFileSearch.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private String filename = null;
 

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/FileSearch.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/FileSearch.java
@@ -31,15 +31,15 @@ import java.util.TreeSet;
 
 import javax.validation.constraints.NotNull;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 /**
  * Searches for all files having a given extension below one or multiple directories.
  */
 public class FileSearch extends AbstractFileSearch {
 
-	private static final Log log = LogFactory.getLog(FileSearch.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(FileSearch.class);
 
 	private String[] suffixes = null;
 

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/FileSearch.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/FileSearch.java
@@ -39,7 +39,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class FileSearch extends AbstractFileSearch {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(FileSearch.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private String[] suffixes = null;
 

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/FileUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/FileUtil.java
@@ -55,7 +55,7 @@ import com.sap.psr.vulas.shared.enums.DigestAlgorithm;
  */
 public class FileUtil {
 
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(FileUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/**
 	 * Returns the file extension of the given {@link File} or null if the file does not have an extension.

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/FileUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/FileUtil.java
@@ -44,8 +44,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.zip.ZipInputStream;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 import com.sap.psr.vulas.shared.enums.DigestAlgorithm;
 
@@ -55,7 +55,7 @@ import com.sap.psr.vulas.shared.enums.DigestAlgorithm;
  */
 public class FileUtil {
 
-	private static final Log log = LogFactory.getLog(FileUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(FileUtil.class);
 
 	/**
 	 * Returns the file extension of the given {@link File} or null if the file does not have an extension.

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/MemoryMonitor.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/MemoryMonitor.java
@@ -19,8 +19,8 @@
  */
 package com.sap.psr.vulas.shared.util;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 /**
  * <p>MemoryMonitor class.</p>
@@ -28,7 +28,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class MemoryMonitor implements Runnable {
 	
-	private static final Log log = LogFactory.getLog(MemoryMonitor.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(MemoryMonitor.class);
 	
 	private long memoSleepTimeMs = 2000;  // Every  2 seconds
 	private long memoPrintTimeMs = 60000; // Every 60 seconds

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/MemoryMonitor.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/MemoryMonitor.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class MemoryMonitor implements Runnable {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(MemoryMonitor.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 	
 	private long memoSleepTimeMs = 2000;  // Every  2 seconds
 	private long memoPrintTimeMs = 60000; // Every 60 seconds

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/StopWatch.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/StopWatch.java
@@ -23,8 +23,7 @@ import java.util.LinkedList;
 
 import javax.validation.constraints.NotNull;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Notes:
@@ -33,7 +32,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class StopWatch {
 
-	private static Log log = LogFactory.getLog(StopWatch.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(StopWatch.class);
 
 	private String id;
 

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/StopWatch.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/StopWatch.java
@@ -32,7 +32,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class StopWatch {
 
-	private static Logger log = org.apache.logging.log4j.LogManager.getLogger(StopWatch.class);
+	private static Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	private String id;
 

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/ThreadUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/ThreadUtil.java
@@ -19,8 +19,8 @@
  */
 package com.sap.psr.vulas.shared.util;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
+
 
 /**
  * <p>ThreadUtil class.</p>
@@ -28,7 +28,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class ThreadUtil {
 	
-	private static final Log log = LogFactory.getLog(ThreadUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ThreadUtil.class);
 
 	/** Constant <code>NO_OF_THREADS="vulas.core.noThreads"</code> */
 	public final static String NO_OF_THREADS = "vulas.core.noThreads";

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/ThreadUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/ThreadUtil.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class ThreadUtil {
 	
-	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ThreadUtil.class);
+	private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
 	/** Constant <code>NO_OF_THREADS="vulas.core.noThreads"</code> */
 	public final static String NO_OF_THREADS = "vulas.core.noThreads";

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/VulasConfiguration.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/VulasConfiguration.java
@@ -56,8 +56,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.configuration.SystemConfiguration;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Logger;
 
 import com.sap.psr.vulas.shared.connectivity.Service;
 import com.sap.psr.vulas.shared.connectivity.ServiceConnectionException;
@@ -88,10 +87,10 @@ import com.sap.psr.vulas.shared.connectivity.ServiceConnectionException;
  */
 public class VulasConfiguration {
 
-	private static Log log = null;
-	private static final synchronized Log getLog() {
+	private static Logger log = null;
+	private static final synchronized Logger getLog() {
 		if(VulasConfiguration.log==null)
-			VulasConfiguration.log = LogFactory.getLog(VulasConfiguration.class);
+			VulasConfiguration.log = org.apache.logging.log4j.LogManager.getLogger(VulasConfiguration.class);
 		return VulasConfiguration.log;
 	}
 

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/VulasConfiguration.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/VulasConfiguration.java
@@ -90,7 +90,7 @@ public class VulasConfiguration {
 	private static Logger log = null;
 	private static final synchronized Logger getLog() {
 		if(VulasConfiguration.log==null)
-			VulasConfiguration.log = org.apache.logging.log4j.LogManager.getLogger(VulasConfiguration.class);
+			VulasConfiguration.log = org.apache.logging.log4j.LogManager.getLogger();
 		return VulasConfiguration.log;
 	}
 

--- a/shared/src/main/resources/log4j.properties
+++ b/shared/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log4j.rootLogger=${vulas.log4j.threshold}, consoleAppender
-
-vulas.log4j.threshold=INFO
-
-log4j.appender.consoleAppender=org.apache.log4j.ConsoleAppender
-log4j.appender.consoleAppender.layout=org.apache.log4j.PatternLayout
-log4j.appender.consoleAppender.layout.ConversionPattern=[%t] %-5p %c %x - %m%n

--- a/shared/src/main/resources/log4j2.xml
+++ b/shared/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+	<Appenders>
+		<Console name="STDOUT" target="SYSTEM_OUT">
+			<PatternLayout pattern="%date [%thread] [%highlight{%-5level}] %-30.30c - %m%n" />
+		</Console>
+	</Appenders>
+	<Loggers>
+		<Root level="${sys:vulas.log4j.threshold:-INFO}">
+			<AppenderRef ref="STDOUT" />
+		</Root>
+	</Loggers>
+</Configuration>

--- a/shared/src/main/resources/log4j2.xml
+++ b/shared/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration>
+<Configuration monitorInterval="300">
 	<Appenders>
 		<Console name="STDOUT" target="SYSTEM_OUT">
 			<PatternLayout pattern="%date [%thread] [%highlight{%-5level}] %-30.30c - %m%n" />

--- a/shared/src/test/java/com/sap/psr/vulas/shared/json/VulnerableDependencyJsonTest.java
+++ b/shared/src/test/java/com/sap/psr/vulas/shared/json/VulnerableDependencyJsonTest.java
@@ -23,17 +23,19 @@
  * and open the template in the editor.
  */
 package com.sap.psr.vulas.shared.json;
-import com.sap.psr.vulas.shared.json.model.ConstructChangeInDependency;
-import com.sap.psr.vulas.shared.json.model.VulnerableDependency;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.List;
 import java.util.Scanner;
-import org.apache.log4j.Logger;
+
+import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
-import java.net.URLDecoder;
+
+import com.sap.psr.vulas.shared.json.model.ConstructChangeInDependency;
+import com.sap.psr.vulas.shared.json.model.VulnerableDependency;
 
 /**
  *
@@ -44,7 +46,7 @@ public class VulnerableDependencyJsonTest {
     @Test
     public void testVulnerableDependecyDeserialization(){
         
-        Logger log = Logger.getLogger(VulnerableDependencyJsonTest.class);
+        final Logger log =  org.apache.logging.log4j.LogManager.getLogger(VulnerableDependencyJsonTest.class);
         String vulndepstring = this.getFile("vulndepJsonExpected.json");
         inputNew = (VulnerableDependency)JacksonUtil.asObject(vulndepstring, VulnerableDependency.class);
         Assert.assertNotEquals(inputNew, null);

--- a/shared/src/test/java/com/sap/psr/vulas/shared/json/VulnerableDependencyJsonTest.java
+++ b/shared/src/test/java/com/sap/psr/vulas/shared/json/VulnerableDependencyJsonTest.java
@@ -46,7 +46,7 @@ public class VulnerableDependencyJsonTest {
     @Test
     public void testVulnerableDependecyDeserialization(){
         
-        final Logger log =  org.apache.logging.log4j.LogManager.getLogger(VulnerableDependencyJsonTest.class);
+        final Logger log =  org.apache.logging.log4j.LogManager.getLogger();
         String vulndepstring = this.getFile("vulndepJsonExpected.json");
         inputNew = (VulnerableDependency)JacksonUtil.asObject(vulndepstring, VulnerableDependency.class);
         Assert.assertNotEquals(inputNew, null);


### PR DESCRIPTION
This PR replaces commons-logging and log4j v1 with log4j v2, and comes with the possibility of [automatic reconfiguration](https://logging.apache.org/log4j/2.x/manual/configuration.html#AutomaticReconfiguration), which is particularly interesting for the components rest-backend and rest-lib-utils.

#### `TODO`s

- [x] Tests
- [x] Documentation