### PR TITLE
Updated ant to 1.10.8

### DIFF
--- a/plugin-maven/pom.xml
+++ b/plugin-maven/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.10.7</version>
+            <version>1.10.8</version>
         </dependency>
 
         <!--instrumentation agent dependency -->

--- a/rest-lib-utils/pom.xml
+++ b/rest-lib-utils/pom.xml
@@ -206,9 +206,9 @@
 			<version>1.2.17</version>
 		</dependency-->
 		<dependency>
-			<groupId>ant</groupId>
+			<groupId>org.apache.ant</groupId>
 			<artifactId>ant</artifactId>
-			<version>1.6.5</version>
+			<version>1.10.8</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Updated then dependencies of plugin-maven and rest-lib-utils. The latter dependency resulted from the use of dependency-finder, and required to update the Maven groupId from `ant` to `org.apache.ant`. 

#### `TODO`s

- [x] Tests
- [x] Documentation