### PR TITLE
consider affected libraries for outer library digest

### DIFF
--- a/rest-backend/src/main/java/org/eclipse/steady/backend/repo/AffectedLibraryRepositoryImpl.java
+++ b/rest-backend/src/main/java/org/eclipse/steady/backend/repo/AffectedLibraryRepositoryImpl.java
@@ -260,18 +260,16 @@ public class AffectedLibraryRepositoryImpl implements AffectedLibraryRepositoryC
     // (required to mark FP entries for the outer library)
     Boolean rebundled = (_vd.getDep().getLib().equals(_lib)) ? false : true;
     Boolean avForRebundled = null;
-    if (rebundled && _vd.getDep().getLib().getLibraryId() != null) {
+    if (rebundled) {
       avForRebundled =
-          this.affLibRepository.isBugLibIdAffected(
-              _vd.getBug().getBugId(), _vd.getDep().getLib().getLibraryId());
+          this.affLibRepository.isBugLibAffected(
+              _vd.getBug().getBugId(), _vd.getDep().getLib().getDigest());
+      if (avForRebundled == null && _vd.getDep().getLib().getLibraryId() != null) {
+        avForRebundled =
+            this.affLibRepository.isBugLibIdAffected(
+                _vd.getBug().getBugId(), _vd.getDep().getLib().getLibraryId());
+      }
     }
-    // TODO: the code below should be used to check whether an affectedLIbrary for the outer libs
-    // exists using the digest (in case the libid is null)
-    // it still needs to be tested
-    //		else if (rebundled){
-    //			avForRebundled = this.affLibRepository.isBugLibAffected(_vd.getBug().getBugId(),
-    // _vd.getDep().getLib().getDigest());
-    //		}
 
     if (avForRebundled != null) {
       _vd.setAffectedVersion((avForRebundled) ? 1 : 0);

--- a/rest-backend/src/main/java/org/eclipse/steady/backend/repo/ApplicationRepositoryImpl.java
+++ b/rest-backend/src/main/java/org/eclipse/steady/backend/repo/ApplicationRepositoryImpl.java
@@ -584,8 +584,11 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
         VulnerableDependency vulndep = new VulnerableDependency(depWithBundledLibId, b);
         vulndep.setVulnDepOrigin(VulnDepOrigin.BUNDLEDAFFLIBID);
         Boolean rebundlingAffected =
-            this.affLibRepository.isBugLibIdAffected(
-                b.getBugId(), depWithBundledLibId.getLib().getLibraryId());
+            this.affLibRepository.isBugLibAffected(
+                b.getBugId(), depWithBundledLibId.getLib().getDigest());
+        if (rebundlingAffected == null)
+          this.affLibRepository.isBugLibIdAffected(
+              b.getBugId(), depWithBundledLibId.getLib().getLibraryId());
         if (rebundlingAffected != null && !rebundlingAffected) vulndep.setAffectedVersion(0);
         else vulndep.setAffectedVersion(1);
         vulndep.setAffectedVersionConfirmed(1);

--- a/rest-backend/src/test/java/org/eclipse/steady/backend/rest/ApplicationControllerTest.java
+++ b/rest-backend/src/test/java/org/eclipse/steady/backend/rest/ApplicationControllerTest.java
@@ -937,7 +937,7 @@ public class ApplicationControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(contentTypeJson))
         .andExpect(jsonPath("$[0].vulnDepOrigin", is("BUNDLEDCC")))
-        .andExpect(jsonPath("$[0].affected", true))
+        .andExpect(jsonPath("$[0].affected", is(true)))
         .andExpect(
             jsonPath("$[0].bundledLib.digest", is("3490508379D065FE3FCB80042B62F630F7588606")));
 
@@ -983,7 +983,7 @@ public class ApplicationControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(contentTypeJson))
         .andExpect(jsonPath("$[0].vulnDepOrigin", is("BUNDLEDCC")))
-        .andExpect(jsonPath("$[0].affected", false))
+        .andExpect(jsonPath("$[0].affected", is(false)))
         .andExpect(
             jsonPath("$[0].bundledLib.digest", is("3490508379D065FE3FCB80042B62F630F7588606")));
   }

--- a/rest-backend/src/test/java/org/eclipse/steady/backend/rest/ApplicationControllerTest.java
+++ b/rest-backend/src/test/java/org/eclipse/steady/backend/rest/ApplicationControllerTest.java
@@ -920,7 +920,7 @@ public class ApplicationControllerTest {
         assertTrue(bundledLibIds.size() == 1);
       else assertTrue(bundledLibIds.size() == 3);
     }
-
+    
     // Read vulndeps
     mockMvc
         .perform(
@@ -937,6 +937,7 @@ public class ApplicationControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(contentTypeJson))
         .andExpect(jsonPath("$[0].vulnDepOrigin", is("BUNDLEDCC")))
+        .andExpect(jsonPath("$[0].affected", true))
         .andExpect(
             jsonPath("$[0].bundledLib.digest", is("3490508379D065FE3FCB80042B62F630F7588606")));
 
@@ -959,6 +960,32 @@ public class ApplicationControllerTest {
         .andExpect(content().contentType(contentTypeJson))
         .andExpect(jsonPath("$.constructList", hasSize(2)))
         .andExpect(jsonPath("$.constructList[0].inArchive", is(true)));
+
+    lib = new Library("3490508379D065FE3FCB80042B62F630F7588606");
+    AffectedLibrary afflib = new AffectedLibrary(bug, null, false, lib, null, null);
+    afflib.setSource(AffectedVersionSource.MANUAL);
+    AffectedLibrary[] afflibs = new AffectedLibrary[1];
+    afflibs[0] = afflib;
+    affLibRepository.customSave(bug, afflibs);
+
+    mockMvc
+        .perform(
+            get("/apps/"
+                    + APP_GROUP
+                    + "/"
+                    + APP_ARTIFACT
+                    + "/"
+                    + "0.0."
+                    + APP_VERSION
+                    + "/vulndeps")
+                .header(Constants.HTTP_TENANT_HEADER, TEST_DEFAULT_TENANT)
+                .header(Constants.HTTP_SPACE_HEADER, TEST_DEFAULT_SPACE))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(contentTypeJson))
+        .andExpect(jsonPath("$[0].vulnDepOrigin", is("BUNDLEDCC")))
+        .andExpect(jsonPath("$[0].affected", false))
+        .andExpect(
+            jsonPath("$[0].bundledLib.digest", is("3490508379D065FE3FCB80042B62F630F7588606")));
   }
 
   @Test

--- a/rest-backend/src/test/java/org/eclipse/steady/backend/rest/ApplicationControllerTest.java
+++ b/rest-backend/src/test/java/org/eclipse/steady/backend/rest/ApplicationControllerTest.java
@@ -920,7 +920,7 @@ public class ApplicationControllerTest {
         assertTrue(bundledLibIds.size() == 1);
       else assertTrue(bundledLibIds.size() == 3);
     }
-    
+
     // Read vulndeps
     mockMvc
         .perform(
@@ -986,7 +986,6 @@ public class ApplicationControllerTest {
         .andExpect(jsonPath("$[0].affected_version", is(0)))
         .andExpect(
             jsonPath("$[0].bundledLib.digest", is("3490508379D065FE3FCB80042B62F630F7588606")));
-    
   }
 
   @Test

--- a/rest-backend/src/test/java/org/eclipse/steady/backend/rest/ApplicationControllerTest.java
+++ b/rest-backend/src/test/java/org/eclipse/steady/backend/rest/ApplicationControllerTest.java
@@ -937,7 +937,7 @@ public class ApplicationControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(contentTypeJson))
         .andExpect(jsonPath("$[0].vulnDepOrigin", is("BUNDLEDCC")))
-        .andExpect(jsonPath("$[0].affected", is(true)))
+        .andExpect(jsonPath("$[0].affected_version", is(1)))
         .andExpect(
             jsonPath("$[0].bundledLib.digest", is("3490508379D065FE3FCB80042B62F630F7588606")));
 
@@ -977,15 +977,16 @@ public class ApplicationControllerTest {
                     + "/"
                     + "0.0."
                     + APP_VERSION
-                    + "/vulndeps")
+                    + "/vulndeps?includeHistorical=true")
                 .header(Constants.HTTP_TENANT_HEADER, TEST_DEFAULT_TENANT)
                 .header(Constants.HTTP_SPACE_HEADER, TEST_DEFAULT_SPACE))
         .andExpect(status().isOk())
         .andExpect(content().contentType(contentTypeJson))
         .andExpect(jsonPath("$[0].vulnDepOrigin", is("BUNDLEDCC")))
-        .andExpect(jsonPath("$[0].affected", is(false)))
+        .andExpect(jsonPath("$[0].affected_version", is(0)))
         .andExpect(
             jsonPath("$[0].bundledLib.digest", is("3490508379D065FE3FCB80042B62F630F7588606")));
+    
   }
 
   @Test


### PR DESCRIPTION
In case of vulnerabilities for bundled libraries (both vulnerabilities with and without code changes), affected libraries defined for the library (digest) of the outer libraries (i.e. the dependency containing the vulnerable library) were not considered. Only affected libraries defined for the outer libraryId (GAV) were kept into account.
