### PR TITLE
Fix for multi release log4j jar

### DIFF
--- a/cli-scanner/pom.xml
+++ b/cli-scanner/pom.xml
@@ -147,10 +147,11 @@
 									<manifestEntries>
 										<Main-Class>org.eclipse.steady.cli.VulasCli</Main-Class>
 										<Specification-Title>${project.name}</Specification-Title>
-			                            <Specification-Version>${project.version}</Specification-Version>
-			                            <Implementation-Title>${project.name}</Implementation-Title>
-			                            <Implementation-Version>${project.version}</Implementation-Version>
-			                            <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
+										<Specification-Version>${project.version}</Specification-Version>
+										<Implementation-Title>${project.name}</Implementation-Title>
+										<Implementation-Version>${project.version}</Implementation-Version>
+			                            				<Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
+										<Multi-Release>true</Multi-Release>
 									</manifestEntries>
 								</transformer>
 							</transformers>

--- a/kb-importer/pom.xml
+++ b/kb-importer/pom.xml
@@ -109,7 +109,7 @@
 									<manifestEntries>
 										<Main-Class>org.eclipse.steady.kb.Main</Main-Class>
 										<Implementation-Version>${project.version}</Implementation-Version>
-										>
+									        <Multi-Release>true</Multi-Release>
 									</manifestEntries>
 								</transformer>
 							</transformers>

--- a/patch-analyzer/pom.xml
+++ b/patch-analyzer/pom.xml
@@ -105,6 +105,7 @@
 									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
 									<manifestEntries>
 										<Main-Class>org.eclipse.steady.patcha.PatchAnalyzer</Main-Class>
+										<Multi-Release>true</Multi-Release>
 									</manifestEntries>
 								</transformer>
 							</transformers>

--- a/patch-lib-analyzer/pom.xml
+++ b/patch-lib-analyzer/pom.xml
@@ -84,6 +84,7 @@
 						</manifest>
 						<manifestEntries>
 							<Main-Class>org.eclipse.steady.patcheval.Main</Main-Class>
+							<Multi-Release>true</Multi-Release>
 						</manifestEntries>
 						<addMavenDescriptor>false</addMavenDescriptor>
 					</archive>


### PR DESCRIPTION
Steady clients kb-importer, patch-analyzer, and others were failing with Java 9 (and later releases).
This is because log4j-api 2.9.1 and above are packaged as a multi-release JAR and support the use of the StackWalker and Process APIs. But the Steady clients do not support muti-release JAR due to which the clients fail with errors. 
The changes in this PR will add muti-release JAR support for Steady clients (by adding the manifest file entry `Multi-Release: true` to self-contained Uber-JARs).