### PR TITLE
Fix escaping of JSON description

### DIFF
--- a/kb-importer/src/main/java/org/eclipse/steady/kb/task/ImportVulnerability.java
+++ b/kb-importer/src/main/java/org/eclipse/steady/kb/task/ImportVulnerability.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.steady.ConstructChange;
 import org.eclipse.steady.backend.BackendConnectionException;
@@ -43,12 +42,11 @@ import org.eclipse.steady.shared.enums.BugOrigin;
 import org.eclipse.steady.shared.enums.ContentMaturityLevel;
 import org.eclipse.steady.shared.json.JsonBuilder;
 import org.eclipse.steady.shared.util.VulasConfiguration;
-
 import com.google.gson.JsonSyntaxException;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
-
 import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
 
 public class ImportVulnerability {
   private Vulnerability vuln;
@@ -164,7 +162,7 @@ public class ImportVulnerability {
     if (notes != null) {
       for (Note note : notes) {
         if (note.getText() != null && !note.getText().isEmpty()) {
-          descriptions.add(StringEscapeUtils.escapeJavaScript(note.getText()));
+          descriptions.add(JSONObject.escape(note.getText()));
         }
 
         List<String> noteLinks = note.getLinks();


### PR DESCRIPTION
Changed the API to escape JSON characters. Formerly used `StringEscapeUtils.escapeJavaScript` escapes single quote characters, which is not required for JSON.