### PR TITLE
Fix logging for messages which contain invalid date formats

### DIFF
--- a/kb-importer/src/main/resources/log4j.properties
+++ b/kb-importer/src/main/resources/log4j.properties
@@ -1,6 +1,0 @@
-log4j.rootLogger=INFO, stdout
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/shared/src/main/resources/log4j2.xml
+++ b/shared/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
 <Configuration monitorInterval="300">
 	<Appenders>
 		<Console name="STDOUT" target="SYSTEM_OUT">
-			<PatternLayout pattern="%date [%thread] [%highlight{%-5level}] %-30.30c - %m%n" />
+			<PatternLayout pattern="%date [%thread] [%highlight{%-5level}] %-30.30c - %m{nolookups}%n" />
 		</Console>
 	</Appenders>
 	<Loggers>


### PR DESCRIPTION
Some message contains date formats which have to be logged as it is. Log4j tries to parse such dates and throws an exception when there are invalid date formats.
Example log which contains **simple(\"myfile-${date:now:yyyyMMdd}.txt\"))** - 
```
MOD JAVA METH [org.apache.camel.component.file.FileConsumerFileExpressionTest.testConsumeFileBasedOnDatePattern()]
F_AST :{"ast":[{"Value":"testConsumeFileBasedOnDatePattern","SourceCodeEntity":{"Modifiers":"0","SourceRange":{"Start":"19","End":"1194"}},"EntityType":"METHOD","C":[{"Value":"template.sendBodyAndHeader(\"file://target/filelanguage/date\", \"Bye World\", Exchange.FILE_NAME, \"myfile-20081128.txt\");","SourceCodeEntity":{"Modifiers":"0","SourceRange":{"Start":"87","End":"204"}},"EntityType":"METHOD_INVOCATION"},{"Value":"template.sendBodyAndHeader(\"file://target/filelanguage/date\", \"Hello World\", Exchange.FILE_NAME, \"myfile-20081129.txt\");","SourceCodeEntity":{"Modifiers":"0","SourceRange":{"Start":"214","End":"333"}},"EntityType":"METHOD_INVOCATION"},{"Value":"template.sendBodyAndHeader(\"file://target/filelanguage/date\", \"Goodday World\", Exchange.FILE_NAME, simple(\"myfile-${date:now:yyyyMMdd}.txt\"));","SourceCodeEntity":{"Modifiers":"0","SourceRange":{"Start":"343","End":"484"}},"EntityType":"METHOD_INVOCATION"},{"Value":"context.addRoutes(new RouteBuilder() {\n  public @Override void configure() throws Exception {\n    from(StringLiteralConcatenation{\"file://target/filelanguage/date/\"+\n\"?fileName=myfile-${date:now:yyyyMMdd}.txt\"+\n}).convertBodyTo(String.class).to(\"mock:result\");\n  }\n});","SourceCodeEntity":{"Modifiers":"0","SourceRange":{"Start":"495","End":"879"}},"EntityType":"METHOD_INVOCATION"},{"Value":"context.start();","SourceCodeEntity":{"Modifiers":"0","SourceRange":{"Start":"889","End":"904"}},"EntityType":"METHOD_INVOCATION"},{"Value":"MockEndpoint mock = getMockEndpoint(\"mock:result\");","SourceCodeEntity":{"Modifiers":"0","SourceRange":{"Start":"1005","End":"1055"}},"EntityType":"VARIABLE_DECLARATION_STATEMENT"},{"Value":"mock.expectedBodiesReceived(\"Goodday World\");","SourceCodeEntity":{"Modifiers":"0","SourceRange":{"Start":"1065","End":"1109"}},"EntityType":"METHOD_INVOCATION"},{"Value":"mock.setResultWaitTime(5000);","SourceCodeEntity":{"Modifiers":"0","SourceRange":{"Start":"1119","End":"1147"}},"EntityType":"METHOD_INVOCATION"},{"Value":"assertMockEndpointsSatisfied();","SourceCodeEntity":{"Modifiers":"0","SourceRange":{"Start":"1158","End":"1188"}},"EntityType":"METHOD_INVOCATION"}]}]}
```

throws exception -
`2020-10-07 10:37:11,269 main ERROR Invalid date format: [now:yyyyMMdd], using default java.lang.IllegalArgumentException: Illegal pattern character 'n'`

To skip this log4j has introduced {nolookups} from 2.13 version. Spec can be found here - https://logging.apache.org/log4j/2.x/manual/layouts.html