### PR TITLE
Make builds of distributed Maven artifacts reproducible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
 		<!-- Skip certain plugins by default, change for all childs to be installed & deployed -->
 		<maven.deploy.skip>true</maven.deploy.skip>
 		
-		<!-- Reproducible -->
+		<!-- Used by several plugins, to make builds reproducible -->
 		<project.build.outputTimestamp>2020-11-02T12:14:00Z</project.build.outputTimestamp>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,9 @@
 		
 		<!-- Skip certain plugins by default, change for all childs to be installed & deployed -->
 		<maven.deploy.skip>true</maven.deploy.skip>
+		
+		<!-- Reproducible -->
+		<project.build.outputTimestamp>2020-11-02T12:14:00Z</project.build.outputTimestamp>
 	</properties>
 
 	<modules>
@@ -194,7 +197,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
-						<version>2.2.1</version>
+						<version>3.2.0</version>
 						<executions>
 							<execution>
 								<id>attach-sources</id>
@@ -209,7 +212,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>3.1.1</version>
+						<version>3.2.0</version>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>
@@ -668,7 +671,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>3.1.0</version>
+					<version>3.2.0</version>
 					<configuration>
 						<archive>
 							<manifestEntries>
@@ -741,13 +744,18 @@
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-war-plugin</artifactId>
+					<version>3.3.1</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.1.0</version>
+					<version>3.2.4</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-assembly-plugin</artifactId>
-					<version>2.6</version>
+					<version>3.3.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Updates the build timestamp and version identifier in files used by Maven, Travis and mkdocs
+# Use to bump versions before and after every release
+
+if [ -z $1 ]; then
+  printf "usage: set-version.sh NEW-VERSION\n\n"
+  printf "Updates the build timestamp and version identifier in files used by Maven, Travis and mkdocs"
+  exit 1
+fi
+
+new=$1
+old=`less pom.xml | grep -m 1 "<version>" | sed -n "s/.*<version>\(.*\)<\/version>.*/\1/p"`
+old_doc=`less docs/public.properties | grep -m 1 "PROJECT_VERSION=" | sed -n "s/PROJECT_VERSION=\(.*\)$/\1/p"`
+
+echo $new | grep -qE "\-SNAPSHOT$"
+if [ $? -eq 0 ]; then
+  is_snap=true
+  printf "Version identifier used by Maven and Travis will be updated to [%s], the one used by mkdocs is kept at [%s]\n" $new $old_doc
+else
+  printf "Version identifier used by Maven, Travis and mkdocs will be updated to [%s]\n" $new
+fi
+
+# Build timestamp
+old_timestamp=`less pom.xml | grep -m 1 "<project.build.outputTimestamp>" | sed -n "s/.*<project.build.outputTimestamp>\(.*\)<\/project.build.outputTimestamp>.*/\1/p"`
+new_timestamp=`date --utc --iso-8601=seconds`
+
+# Maven
+find . -name pom.xml -exec sed -i "s/${old}/${new}/" {} \;
+sed -i "s/${old_timestamp}/${new_timestamp}/" .travis/.env
+
+# Travis
+sed -i "s/${old}/${new}/" .travis/.env
+
+# mkdocs (keep current if new version is snapshot)
+if [ -z $is_snap ]; then
+  sed -i "s/${old_doc}/${new}/" docs/mkdocs.yml
+  sed -i "s/${old_doc}/${new}/" docs/public.properties
+fi
+
+# Kubernetes doc files
+find kubernetes -name README.md -exec sed -i "s/${old}/${new}/" {} \;

--- a/set-version.sh
+++ b/set-version.sh
@@ -27,9 +27,6 @@ new_timestamp=`date --utc --iso-8601=seconds`
 
 # Maven
 find . -name pom.xml -exec sed -i "0,/${old}/s//${new}/" {} \;
-
-exit 0
-
 sed -i "s/${old_timestamp}/${new_timestamp}/" pom.xml
 
 # Travis

--- a/set-version.sh
+++ b/set-version.sh
@@ -26,7 +26,10 @@ old_timestamp=`less pom.xml | grep -m 1 "<project.build.outputTimestamp>" | sed 
 new_timestamp=`date --utc --iso-8601=seconds`
 
 # Maven
-find . -name pom.xml -exec sed -i "s/${old}/${new}/" {} \;
+find . -name pom.xml -exec sed -i "0,/${old}/s//${new}/" {} \;
+
+exit 0
+
 sed -i "s/${old_timestamp}/${new_timestamp}/" pom.xml
 
 # Travis

--- a/set-version.sh
+++ b/set-version.sh
@@ -16,9 +16,9 @@ old_doc=`less docs/public.properties | grep -m 1 "PROJECT_VERSION=" | sed -n "s/
 echo $new | grep -qE "\-SNAPSHOT$"
 if [ $? -eq 0 ]; then
   is_snap=true
-  printf "Version identifier used by Maven and Travis will be updated to [%s], the one used by mkdocs is kept at [%s]\n" $new $old_doc
+  printf "Version identifier used by Maven and Travis will be updated from [%s] to [%s], the one used by mkdocs is kept at [%s]\n" $old $new $old_doc
 else
-  printf "Version identifier used by Maven, Travis and mkdocs will be updated to [%s]\n" $new
+  printf "Version identifier used by Maven, Travis and mkdocs will be updated from [%s] to [%s]\n" $old $new
 fi
 
 # Build timestamp

--- a/set-version.sh
+++ b/set-version.sh
@@ -27,7 +27,7 @@ new_timestamp=`date --utc --iso-8601=seconds`
 
 # Maven
 find . -name pom.xml -exec sed -i "s/${old}/${new}/" {} \;
-sed -i "s/${old_timestamp}/${new_timestamp}/" .travis/.env
+sed -i "s/${old_timestamp}/${new_timestamp}/" pom.xml
 
 # Travis
 sed -i "s/${old}/${new}/" .travis/.env


### PR DESCRIPTION
Updated plugins to versions that support [reproducible builds](https://reproducible-builds.org/docs/jvm/).
Added script to facilitate the bumping of versions before and after a release.

Check reproducibility of distributed maven artifacts with
```
mvn clean install -e -DskipTests
mvn clean verify -e -DskipTests artifact:buildinfo
```

More information at
- https://maven.apache.org/guides/mini/guide-reproducible-builds.html
- https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=74682318.
#### `TODO`s

- [ ] Tests
- [ ] Documentation