### PR TITLE
fix: REUSE compliance

### DIFF
--- a/kb-importer/src/main/java/org/eclipse/steady/kb/util/ConstructSet.java
+++ b/kb-importer/src/main/java/org/eclipse/steady/kb/util/ConstructSet.java
@@ -1,18 +1,20 @@
 /**
  * This file is part of Eclipse Steady.
  *
- * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * <p>SPDX-License-Identifier: Apache-2.0 SPDX-FileCopyrightText: Copyright (c) 2018-2020 SAP SE or
- * an SAP affiliate company and Eclipse Steady contributors
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2020 SAP SE or an SAP affiliate company and Eclipse Steady contributors
  */
 package org.eclipse.steady.kb.util;
 


### PR DESCRIPTION
[REUSE](https://api.reuse.software/info/github.com/eclipse/steady) shows the batch is non-compliant. 
The issue was with ConstructSet.java which is fixed with this PR.