### PR TITLE
Fix kb-imorter for Mac and Windows

### DIFF
--- a/docker/kb-importer/start.sh
+++ b/docker/kb-importer/start.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 #kaybee update
+mkdir -p /kb-importer/data
 cd /kb-importer/data
 mv /kb-importer/kb-importer.jar /kb-importer/kaybee /kb-importer/data
 ./kaybee update --force


### PR DESCRIPTION
This fix is for Mac and Windows. Docker does not have native support for Mac and Windows. Docker volumes work very slow on Mac and Windows.
The workaround for now is removing the volumes of kb-importer and running the docker containers -
```
      - "./kb-importer/data:/kb-importer/data:delegated"
      - "./kb-importer/tmp:/tmp:delegated"
```