### PR TITLE
Updated Soot and it the default callgraph construction fwk

### DIFF
--- a/docs/public/content/user/manuals/analysis.md
+++ b/docs/public/content/user/manuals/analysis.md
@@ -120,7 +120,7 @@ The first objective supports the risk assessment for a given vulnerability, whil
 #### Limitations
 
 - Python is not supported
-- Java 9 and later versions are not supported by the underlying frameworks
+- Java 9 and later versions are only supported when using Soot as call graph construction framework
 
 #### Result
 
@@ -157,7 +157,7 @@ vulas.reach.bugs =
 
 # Analysis framework to be used
 # Possible values: wala, soot
-vulas.reach.fwk = wala
+vulas.reach.fwk = soot
 
 # Regex to filter entry points (semicolon separated)
 vulas.reach.constructFilter =

--- a/docs/public/content/user/manuals/analysis.md
+++ b/docs/public/content/user/manuals/analysis.md
@@ -268,7 +268,7 @@ vulas.reach.soot.spark.rta     = false
 # | none (default)                                                      | no 'DummyMainMethod' is generated (default)                                                          |
 # | soot.jimple.infoflow.entryPointCreators.SequentialEntryPointCreator | a 'DummyMainMethod' that invokes all entrypoints is generated                                        |
 # | soot.jimple.infoflow.entryPointCreators.DefaultEntryPointCreator    | a 'DummyMainMethod' in which all entrypoints are generated (random order)                            |
-# | com.sap.psr.vulas.cg.soot.CustomEntryPointCreator                   | same as DefaultEntryPointCreated + for abstract classes/interface a dummy implementation is generated |
+# | org.eclipse.steady.cg.soot.CustomEntryPointCreator                   | same as DefaultEntryPointCreated + for abstract classes/interface a dummy implementation is generated |
 vulas.reach.soot.entrypointGenerator = none
 ```
 

--- a/lang-java-reach-soot/pom.xml
+++ b/lang-java-reach-soot/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>ca.mcgill.sable</groupId>
 			<artifactId>soot</artifactId>
-			<version>3.3.0</version>
+			<version>4.1.0</version>
 			<scope>compile</scope>
 			<exclusions>
 				<exclusion>
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>de.tud.sse</groupId>
 			<artifactId>soot-infoflow</artifactId>
-			<version>2.7.1.1</version>
+			<version>2.8</version>
 			<scope>compile</scope>
 			<!-- Defined in its dependency on soot:3.2.0, which is any how irrelevant 
 				due to the above dep on soot:3.2.0 -->
@@ -74,6 +74,10 @@
 				<exclusion>
 					<groupId>ca.mcgill.sable</groupId>
 					<artifactId>jasmin</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/lang-java-reach-soot/src/main/java/org/eclipse/steady/cg/soot/CustomEntryPointCreator.java
+++ b/lang-java-reach-soot/src/main/java/org/eclipse/steady/cg/soot/CustomEntryPointCreator.java
@@ -309,7 +309,7 @@ public class CustomEntryPointCreator extends DefaultEntryPointCreator {
     return generatedMethod;
   }
 
-  private Type getSimpleTypeFromType(Type type) {
+  protected Type getSimpleTypeFromType(Type type) {
     if (type.toString().equals("java.lang.String")) {
       assert type instanceof RefType;
 

--- a/lang-java-reach/pom.xml
+++ b/lang-java-reach/pom.xml
@@ -51,17 +51,17 @@
 		<dependency>
 			<groupId>com.ibm.wala</groupId>
 			<artifactId>com.ibm.wala.core</artifactId>
-			<version>1.5.6</version>
+			<version>1.4.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.wala</groupId>
 			<artifactId>com.ibm.wala.util</artifactId>
-			<version>1.5.6</version>
+			<version>1.4.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.wala</groupId>
 			<artifactId>com.ibm.wala.shrike</artifactId>
-			<version>1.5.6</version>
+			<version>1.4.3</version>
 		</dependency>
 
 		<!-- Test -->

--- a/lang-java-reach/pom.xml
+++ b/lang-java-reach/pom.xml
@@ -51,17 +51,17 @@
 		<dependency>
 			<groupId>com.ibm.wala</groupId>
 			<artifactId>com.ibm.wala.core</artifactId>
-			<version>1.4.3</version>
+			<version>1.5.6</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.wala</groupId>
 			<artifactId>com.ibm.wala.util</artifactId>
-			<version>1.4.3</version>
+			<version>1.5.6</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.wala</groupId>
 			<artifactId>com.ibm.wala.shrike</artifactId>
-			<version>1.4.3</version>
+			<version>1.5.6</version>
 		</dependency>
 
 		<!-- Test -->

--- a/lang-java-reach/src/main/resources/vulas-reach.properties
+++ b/lang-java-reach/src/main/resources/vulas-reach.properties
@@ -26,7 +26,7 @@ vulas.reach.bugs =
 
 # Analysis framework to be used
 # Possible values: wala, soot
-vulas.reach.fwk = wala
+vulas.reach.fwk = soot
 
 # Whether or not to stop the CG analysis as soon as entry points 
 # supposed to be used for the callgraph construction cannot be found by the 

--- a/lang-java/pom.xml
+++ b/lang-java/pom.xml
@@ -185,6 +185,10 @@
 									<pattern>org.apache.http</pattern>
 									<shadedPattern>org.eclipse.steady.repackaged.org.apache.http</shadedPattern>
 								</relocation>
+								<relocation>
+									<pattern>javassist</pattern>
+									<shadedPattern>org.eclipse.steady.repackaged.javassist</shadedPattern>
+								</relocation>
 							</relocations>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
 			<dependency>
 				<groupId>org.javassist</groupId>
 				<artifactId>javassist</artifactId>
-				<version>3.27.0-GA</version>
+				<version>3.28.0-GA</version>
 			</dependency>
 			<dependency>
 				<groupId>org.antlr</groupId>


### PR DESCRIPTION
Upgraded Soot from 3.3.0 to 4.1.0 to perform the reachability analysis on Java versions greater than 8, and made Soot the default call graph construction framework by setting `vulas.reach.fwk = soot`

- [ ] Tests
- [x] Documentation