### PR TITLE
Changed Velocity variable names

### DIFF
--- a/lang/src/main/java/org/eclipse/steady/report/Report.java
+++ b/lang/src/main/java/org/eclipse/steady/report/Report.java
@@ -36,7 +36,6 @@ import java.util.TreeSet;
 import javax.validation.constraints.NotNull;
 
 import org.apache.logging.log4j.Logger;
-
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
@@ -426,7 +425,7 @@ public class Report {
 
     // Basic info
     this.context.put(
-        "vulas-backend-serviceUrl",
+        "vulasBackendServiceUrl",
         this.goalContext.getVulasConfiguration().getServiceUrl(Service.BACKEND));
     this.context.put("app", app);
     this.context.put("space", this.goalContext.getSpace());
@@ -457,7 +456,7 @@ public class Report {
             .getConfiguration()
             .getString(VulasConfiguration.BUILD_BRANCH, "unknown"));
     this.context.put(
-        "vulas-shared-homepage",
+        "vulasSharedHomepage",
         this.goalContext
             .getVulasConfiguration()
             .getConfiguration()

--- a/lang/src/main/resources/velocity_template.html
+++ b/lang/src/main/resources/velocity_template.html
@@ -393,10 +393,10 @@
 
 						<h2>Links: </h2>
 						<div class="target-summary">
-							<span><a href="$vulas-shared-homepage/user/manuals" target="_blank">Docs - User Manual</a></span><br>
-							<span><a href="$vulas-shared-homepage/user/manuals/assess_and_mitigate" target="_blank">Docs - Assess and Mitigate</a></span><br>
-							<span><a href="$vulas-shared-homepage/user/support" target="_blank">Docs - Getting Help</a></span><br>
-							<span><a href="$vulas-backend-serviceUrl/../apps/#/$space.getSpaceToken()" target="_blank">Web Frontend</a></span><br>
+							<span><a href="$vulasSharedHomepage/user/manuals" target="_blank">Docs - User Manual</a></span><br>
+							<span><a href="$vulasSharedHomepage/user/manuals/assess_and_mitigate" target="_blank">Docs - Assess and Mitigate</a></span><br>
+							<span><a href="$vulasSharedHomepage/user/support" target="_blank">Docs - Getting Help</a></span><br>
+							<span><a href="$vulasBackendServiceUrl/../apps/#/$space.getSpaceToken()" target="_blank">Web Frontend</a></span><br>
 						</div>
 					</td>
 					<td valign="top" width="75%">
@@ -544,7 +544,7 @@
 														#foreach( $analysis in $vul.analyses )
 														<li>
 															<div class="tooltip">
-																<a href="$vulas-backend-serviceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()"
+																<a href="$vulasBackendServiceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()"
 																#if($exceptionThreshold=='dependsOn' && $analysis.isThrowsException()) style="color: #e94f37; font-weight: bold;"
 																#elseif($exceptionThreshold=='dependsOn' && $analysis.isThrowsExceptionExcluded()) style="color: #a5b452; font-weight: bold;"
 																#else style="color: #393e41; font-weight: bold"
@@ -585,7 +585,7 @@
 														#if( !$analysis.isNoneAffectedVersion())
 														<li>
 															<div class="tooltip">
-															<a href="$vulas-backend-serviceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()"
+															<a href="$vulasBackendServiceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()"
 															#if( $exceptionThreshold=='potentiallyExecutes' && $analysis.isThrowsException()) style="color: #e94f37; font-weight: bold;"
 															#elseif($exceptionThreshold=='potentiallyExecutes' && $analysis.isThrowsExceptionExcluded()) style="color: #a5b452; font-weight: bold;"
 															#else style="color: #393e41; font-weight: bold"
@@ -627,7 +627,7 @@
 														#if( !$analysis.isNoneAffectedVersion())
 														<li>
 															<div class="tooltip">
-																<a href="$vulas-backend-serviceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()"
+																<a href="$vulasBackendServiceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()"
 																#if( $exceptionThreshold=='actuallyExecutes' && $analysis.isThrowsException()) style="color: #e94f37; font-weight: bold;"
 																#elseif($exceptionThreshold=='actuallyExecutes' && $analysis.isThrowsExceptionExcluded()) style="color: #a5b452; font-weight: bold;"
 																#else style="color: #393e41; font-weight: bold"
@@ -747,7 +747,7 @@
 														#foreach( $analysis in $vul.analyses )
 														<li>
 															<div class="tooltip">
-																<a href="$vulas-backend-serviceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()"
+																<a href="$vulasBackendServiceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()"
 																#if($exceptionThreshold=='dependsOn' && $analysis.isThrowsException()) style="color: #e94f37; font-weight: bold;"
 																#elseif($exceptionThreshold=='dependsOn' && $analysis.isThrowsExceptionExcluded()) style="color: #e94f37; font-weight: bold;"
 																#else style="color: #393e41; font-weight: bold"
@@ -789,7 +789,7 @@
 														#if( !$analysis.isNoneAffectedVersion())
 														<li>
 															<div class="tooltip">
-															<a href="$vulas-backend-serviceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()"
+															<a href="$vulasBackendServiceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()"
 															#if( $exceptionThreshold=='potentiallyExecutes' && $analysis.isThrowsException()) style="color: #e94f37; font-weight: bold;"
 															#elseif($exceptionThreshold=='potentiallyExecutes' && $analysis.isThrowsExceptionExcluded()) style="color: #e94f37; font-weight: bold;"
 															#else style="color: #393e41; font-weight: bold"
@@ -831,7 +831,7 @@
 														#if( !$analysis.isNoneAffectedVersion())
 														<li>
 															<div class="tooltip">
-																<a href="$vulas-backend-serviceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()"
+																<a href="$vulasBackendServiceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()"
 																#if( $exceptionThreshold=='actuallyExecutes' && $analysis.isThrowsException()) style="color: #e94f37; font-weight: bold;"
 																#elseif($exceptionThreshold=='actuallyExecutes' && $analysis.isThrowsExceptionExcluded()) style="color: #e94f37; font-weight: bold;"
 																#else style="color: #393e41; font-weight: bold"

--- a/lang/src/main/resources/velocity_template.json
+++ b/lang/src/main/resources/velocity_template.json
@@ -63,7 +63,7 @@
 				"artifactId": "$analysis.getApp().getArtifact()",
 				"version": "$analysis.getApp().getVersion()",
 				
-				"href": "$vulas-backend-serviceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()",
+				"href": "$vulasBackendServiceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()",
 				
 				"scope": "$analysis.getDep().getScope()",
 				"isTransitive": $analysis.getDep().getTransitive(),

--- a/lang/src/main/resources/velocity_template.xml
+++ b/lang/src/main/resources/velocity_template.xml
@@ -87,7 +87,7 @@
 				<version>$analysis.getApp().getVersion()</version>
 				
 				<!-- Link to the frontend with detailled analysis results -->
-				<href>$vulas-backend-serviceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()</href>
+				<href>$vulasBackendServiceUrl/../apps/#/$space.getSpaceToken()/$analysis.getApp().getMvnGroup()/$analysis.getApp().getArtifact()/$analysis.getApp().getVersion()</href>
 				
 				<!-- Details regarding the dependency of the app/module on the library containing vulnerable code -->
 				<scope>$analysis.getDep().getScope()</scope>


### PR DESCRIPTION
Velocity template variables `$vulas-shared-homepage` and `$vulas-backend-serviceUrl` were not any more populated when generating the report. This regression was probably introduced with commit  ff4c80ad54f513153d05d1fbaf4b475f3957309f, when switching from Velocity version 1.7 to 2.3. According to the [Velocity Template Language](https://velocity.apache.org/engine/2.3/vtl-reference.html), hyphens are not anymore allowed for identifiers (by default).


Using camel case solves the issue. 

#### `TODO`s

- [x] Tests
- [ ] Documentation