### PR TITLE
Added timeout to rest_template for Maven Central

### DIFF
--- a/rest-lib-utils/src/main/java/org/eclipse/steady/cia/util/MavenCentralWrapper.java
+++ b/rest-lib-utils/src/main/java/org/eclipse/steady/cia/util/MavenCentralWrapper.java
@@ -66,7 +66,7 @@ public class MavenCentralWrapper implements RepositoryWrapper {
   private static Set<ProgrammingLanguage> SUPP_LANG = new HashSet<ProgrammingLanguage>();
 
   private RestTemplate rest_template;
-  
+
   static {
     SUPP_LANG.add(ProgrammingLanguage.JAVA);
     MAVEN_CENTRAL_REPO =
@@ -87,11 +87,15 @@ public class MavenCentralWrapper implements RepositoryWrapper {
             .getInteger("vulas.lib-utils.mavencentral.retrycount", 3);
     if (MAVEN_CENTRAL_REPO != null && baseUrl != null) CONFIGURED = true;
   }
-  
-  public MavenCentralWrapper(){
-	  super();
-	  RestTemplateBuilder builder = new RestTemplateBuilder();
-	  this.rest_template = builder.setConnectTimeout(Duration.ofMillis(5000)).setReadTimeout(Duration.ofMillis(5000)).build();
+
+  public MavenCentralWrapper() {
+    super();
+    RestTemplateBuilder builder = new RestTemplateBuilder();
+    this.rest_template =
+        builder
+            .setConnectTimeout(Duration.ofMillis(5000))
+            .setReadTimeout(Duration.ofMillis(5000))
+            .build();
   }
 
   /** {@inheritDoc} */
@@ -112,7 +116,7 @@ public class MavenCentralWrapper implements RepositoryWrapper {
 
   private MavenVersionsSearch getFromMavenCentral(Map<String, String> _params)
       throws InterruptedException {
-	
+
     ResponseEntity<MavenVersionsSearch> responseEntity = null;
 
     for (Integer i = 1; i < this.mavenCentralRetryCount + 1; i++) {
@@ -259,7 +263,7 @@ public class MavenCentralWrapper implements RepositoryWrapper {
     b.append(_doc.getM2Filename());
 
     // Make the query
-    
+
     Path result = null;
     try {
       rest_template.execute(
@@ -289,7 +293,7 @@ public class MavenCentralWrapper implements RepositoryWrapper {
       params.put("core", "gav");
 
       // Make the query
-      
+
       final MavenVersionsSearch search =
           rest_template.getForObject(baseUrl, MavenVersionsSearch.class, params);
 

--- a/rest-lib-utils/src/main/java/org/eclipse/steady/cia/util/MavenCentralWrapper.java
+++ b/rest-lib-utils/src/main/java/org/eclipse/steady/cia/util/MavenCentralWrapper.java
@@ -19,6 +19,7 @@
 package org.eclipse.steady.cia.util;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -37,6 +38,7 @@ import org.eclipse.steady.shared.json.model.mavenCentral.ResponseDoc;
 import org.eclipse.steady.shared.util.VulasConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
@@ -63,6 +65,8 @@ public class MavenCentralWrapper implements RepositoryWrapper {
 
   private static Set<ProgrammingLanguage> SUPP_LANG = new HashSet<ProgrammingLanguage>();
 
+  private RestTemplate rest_template;
+  
   static {
     SUPP_LANG.add(ProgrammingLanguage.JAVA);
     MAVEN_CENTRAL_REPO =
@@ -83,6 +87,12 @@ public class MavenCentralWrapper implements RepositoryWrapper {
             .getInteger("vulas.lib-utils.mavencentral.retrycount", 3);
     if (MAVEN_CENTRAL_REPO != null && baseUrl != null) CONFIGURED = true;
   }
+  
+  public MavenCentralWrapper(){
+	  super();
+	  RestTemplateBuilder builder = new RestTemplateBuilder();
+	  this.rest_template = builder.setConnectTimeout(Duration.ofMillis(5000)).setReadTimeout(Duration.ofMillis(5000)).build();
+  }
 
   /** {@inheritDoc} */
   @Override
@@ -102,7 +112,7 @@ public class MavenCentralWrapper implements RepositoryWrapper {
 
   private MavenVersionsSearch getFromMavenCentral(Map<String, String> _params)
       throws InterruptedException {
-    final RestTemplate rest_template = new RestTemplate();
+	
     ResponseEntity<MavenVersionsSearch> responseEntity = null;
 
     for (Integer i = 1; i < this.mavenCentralRetryCount + 1; i++) {
@@ -249,7 +259,7 @@ public class MavenCentralWrapper implements RepositoryWrapper {
     b.append(_doc.getM2Filename());
 
     // Make the query
-    final RestTemplate rest_template = new RestTemplate();
+    
     Path result = null;
     try {
       rest_template.execute(
@@ -279,7 +289,7 @@ public class MavenCentralWrapper implements RepositoryWrapper {
       params.put("core", "gav");
 
       // Make the query
-      final RestTemplate rest_template = new RestTemplate();
+      
       final MavenVersionsSearch search =
           rest_template.getForObject(baseUrl, MavenVersionsSearch.class, params);
 


### PR DESCRIPTION
The addition of  a timeout to the rest requests to Maven central is meant to mitigate #183  by avoiding waiting for the gateway timeout (HTTP 504)