### PR TITLE
Updated maven-gpg-plugin and added condition on tag name to trigger deployments on Maven Central

### DIFF
--- a/.pipeline/config.yml
+++ b/.pipeline/config.yml
@@ -1,2 +1,0 @@
-general:
-  buildTool: 'maven'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,10 +111,11 @@ spec:
     // Verifies that artifacts can be signed with GPG (required for releases on Maven Central).
     // https://www.jenkins.io/doc/book/pipeline/syntax/
     stage('Release on Central') {
-      when { branch "sign-releases" }
+      //when { branch "sign-releases" }
       // when { tag "release-*" }
       steps {
         container('maven') {
+          echo "Environment: ${env}"
           sh 'gpg --version'
           withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING')]) {
             sh 'gpg --batch --import "${KEYRING}"'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ spec:
     stage('Verify Spotbugs') {
       steps {
         container('maven') {
-          sh 'mvn -e -P gradle -Dvulas.shared.m2Dir=/home/jenkins/agent/workspace -Dspring.standalone \
+          sh 'mvn -B -e -P gradle -Dvulas.shared.m2Dir=/home/jenkins/agent/workspace -Dspring.standalone \
               -Dspotbugs.excludeFilterFile=findbugs-exclude.xml -Dspotbugs.includeFilterFile=findbugs-include.xml \
               -Dspotbugs.failOnError=true -DskipTests clean install com.github.spotbugs:spotbugs-maven-plugin:4.2.3:check'
         }
@@ -86,7 +86,7 @@ spec:
     stage('Verify JavaDoc') {
       steps {
         container('maven') {
-          sh 'mvn -e -P gradle,javadoc -Dspring.standalone -DskipTests clean package'
+          sh 'mvn -B -e -P gradle,javadoc -Dspring.standalone -DskipTests clean package'
         }
       }
     }
@@ -103,7 +103,7 @@ spec:
     stage('Test') {
       steps {
         container('maven') {
-          sh 'mvn -e -P gradle -Dvulas.shared.m2Dir=/home/jenkins/agent/workspace -Dspring.standalone \
+          sh 'mvn -B -e -P gradle -Dvulas.shared.m2Dir=/home/jenkins/agent/workspace -Dspring.standalone \
               -Dit.test="!IT01_PatchAnalyzerIT,IT*,*IT" -DfailIfNoTests=false clean test'
         }
       }
@@ -111,11 +111,12 @@ spec:
     // Verifies that artifacts can be signed with GPG (required for releases on Maven Central).
     // https://www.jenkins.io/doc/book/pipeline/syntax/
     stage('Release on Central') {
-      //when { branch "sign-releases" }
+      // when { branch "sign-releases" }
       // when { tag "release-*" }
       steps {
         container('maven') {
-          echo "Environment: ${env}"
+          echo "Environment: ${env.BRANCH_NAME}"
+          echo "Environment: ${env.TAG_NAME}"
           sh 'gpg --version'
           withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING')]) {
             sh 'gpg --batch --import "${KEYRING}"'

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.5</version>
+						<version>3.0.1</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -244,6 +244,7 @@
 								</goals>
 								<configuration>
 									<gpgArguments>
+										<arg>--verbose</arg>
 										<arg>--pinentry-mode</arg>
 										<arg>loopback</arg>
 									</gpgArguments>

--- a/repo-client/pom.xml
+++ b/repo-client/pom.xml
@@ -78,7 +78,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.2</version>
 				<configuration>
 					<compilerArgument>-g</compilerArgument>
 				</configuration>

--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -373,7 +373,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.5</version>
+						<version>3.0.1</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/rest-lib-utils/pom.xml
+++ b/rest-lib-utils/pom.xml
@@ -359,7 +359,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.5</version>
+						<version>3.0.1</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>


### PR DESCRIPTION
Updated the `maven-gpg-plugin` from version 1.5 to 3.0.1, and added condition to GPG sign and deploy on Maven Central upon the creation of `release-*` tags.