### PR TITLE
Make builds reproducible and add corresponding check in Jenkins pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ kubernetes/helm/vulnerability-assessment-tool-admin/charts/nginx-ingress/files/t
 /docker/**/import_vulas_kb.sh
 google-java-format-*.jar
 .DS_Store
+**/*.buildinfo

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ spec:
           sh 'mvn -B -e -P gradle,javadoc -Dspring.standalone -DskipTests clean install'
           sh 'mvn -B -e -P gradle,javadoc -Dspring.standalone -DskipTests -Dreference.repo=https://repo.maven.apache.org/maven2 clean verify'
           sh 'cat target/root-*.buildinfo.compare'
-          //sh 'grep ko=0 target/root-*.buildinfo.compare' // Fail if JARs are different
+          sh 'grep ko=0 target/root-*.buildinfo.compare' // Fail if JARs are different
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,12 +81,16 @@ spec:
         }
       }
     }
-    // Verifies that the Javadoc documentation can be generated (by enabling the
-    // javadoc profile contained in three pom.xml files).
-    stage('Verify JavaDoc') {
+    // Verifies that the -javadoc and -sources artifacts can be generated (by enabling the
+    // javadoc profile contained in three pom.xml files). Also verifies that the build
+    // is reproducible.
+    stage('Verify JavaDoc, Source and Reproducibility') {
       steps {
         container('maven') {
-          sh 'mvn -B -e -P gradle,javadoc -Dspring.standalone -DskipTests clean package'
+          sh 'mvn -B -e -P gradle,javadoc -Dspring.standalone -DskipTests clean install'
+          sh 'mvn -B -e -P gradle,javadoc -Dspring.standalone -DskipTests -Dreference.repo=https://repo.maven.apache.org/maven2 clean verify'
+          sh 'cat target/root-*.buildinfo.compare'
+          //sh 'grep ko=0 target/root-*.buildinfo.compare' // Fail if JARs are different
         }
       }
     }

--- a/frontend-apps/pom.xml
+++ b/frontend-apps/pom.xml
@@ -99,7 +99,7 @@
 								</replacement>
 								<replacement>
 									<token>$buildTimestamp$</token>
-									<value>${maven.build.timestamp}</value>
+									<value>${project.build.outputTimestamp}</value>
 								</replacement>
 								<replacement>
 									<token>$buildNumber$</token>

--- a/frontend-bugs/pom.xml
+++ b/frontend-bugs/pom.xml
@@ -98,7 +98,7 @@
 						</replacement>
 						<replacement>
 							<token>$buildTimestamp$</token>
-							<value>${maven.build.timestamp}</value>
+							<value>${project.build.outputTimestamp}</value>
 						</replacement>
 						<replacement>
 							<token>$buildNumber$</token>

--- a/patch-lib-analyzer/pom.xml
+++ b/patch-lib-analyzer/pom.xml
@@ -70,7 +70,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.5.3</version>
 				<configuration>
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>

--- a/plugin-gradle/build.gradle
+++ b/plugin-gradle/build.gradle
@@ -10,6 +10,13 @@ gradlePlugin {
     }
 }
 
+// Make created JAR files reproducible (cf.
+// https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives).
+tasks.withType(AbstractArchiveTask).configureEach {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}
+
 def getClasspathFiles(String classpathListRelativePath) {
     def classpathListFile = new File(classpathListRelativePath)
     

--- a/plugin-gradle/pom.xml
+++ b/plugin-gradle/pom.xml
@@ -35,7 +35,7 @@
     <description></description>
     
     <properties>
-        <gradle.distribution.url>https://services.gradle.org/distributions/gradle-5.0-bin.zip</gradle.distribution.url>
+        <gradle.distribution.url>https://services.gradle.org/distributions/gradle-6.8.3-bin.zip</gradle.distribution.url>
         <gradle.executable>./gradlew</gradle.executable>
         <gradle.task>build</gradle.task>
         <maven.deploy.skip>false</maven.deploy.skip>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.android.tools.build</groupId>
             <artifactId>gradle</artifactId>
-            <version>3.3.2</version>
+            <version>4.2.1</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -160,7 +160,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.6.0</version>
+                <version>3.0.0</version>
                 <configuration>
                     <executable>${gradle.executable}</executable>
                     <arguments combine.children="append">
@@ -241,7 +241,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
 		<maven.deploy.skip>true</maven.deploy.skip>
 		
 		<!-- Used by several plugins, to make builds reproducible -->
-		<project.build.outputTimestamp>2020-11-02T12:14:00Z</project.build.outputTimestamp>
+		<project.build.outputTimestamp>2021-06-22T10:45:00Z</project.build.outputTimestamp>
 	</properties>
 
 	<modules>
@@ -226,7 +226,9 @@
 			</build>
 		</profile>
 
-		<!-- Activate when deploying to the Central Repo. Also see https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release -->
+		<!-- Activate when deploying to the Central Repo. Also see
+		https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release
+		-->
 		<profile>
 			<id>release</id>
 			<build>
@@ -252,7 +254,9 @@
 							</execution>
 						</executions>
 					</plugin>
-					<!-- Deploy to the Central Repository according to https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release. -->
+					<!-- Deploy to the Central Repository according to
+					https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release.
+					-->
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
 						<artifactId>nexus-staging-maven-plugin</artifactId>
@@ -428,6 +432,30 @@
 						<phase>clean</phase>
 						<goals>
 							<goal>clean</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!--
+				See
+				https://maven.apache.org/guides/mini/guide-reproducible-builds.html,
+				https://maven.apache.org/plugins/maven-artifact-plugin/buildinfo-mojo.html#referenceRepo.
+			-->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-artifact-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<reproducible>false</reproducible>
+					<referenceCompareSave>true</referenceCompareSave>
+				</configuration>
+				<executions>
+					<execution>
+						<id>buildinfo</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>buildinfo</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -449,6 +449,7 @@
 				<configuration>
 					<reproducible>false</reproducible>
 					<referenceCompareSave>true</referenceCompareSave>
+					<detectSkip>false</detectSkip>
 				</configuration>
 				<executions>
 					<execution>

--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -111,6 +111,8 @@
 		<maven.install.skip>${skip.install.deploy}</maven.install.skip>
 		<maven.deploy.skip>${skip.install.deploy}</maven.deploy.skip>
 		
+		<!-- Used by several plugins, to make builds reproducible -->
+		<project.build.outputTimestamp>2021-06-22T10:45:00Z</project.build.outputTimestamp>
 	</properties>
 	
 	<dependencies>
@@ -428,6 +430,7 @@
 			<plugin>
 			    <groupId>org.apache.maven.plugins</groupId>
 			    <artifactId>maven-jar-plugin</artifactId>
+				<version>3.2.0</version>
 			    <configuration>
 				<archive>
 				    <manifestEntries>

--- a/rest-lib-utils/pom.xml
+++ b/rest-lib-utils/pom.xml
@@ -116,7 +116,9 @@
 		<skip.install.deploy>true</skip.install.deploy>
 		<maven.install.skip>${skip.install.deploy}</maven.install.skip>
 		<maven.deploy.skip>${skip.install.deploy}</maven.deploy.skip>
-		
+
+		<!-- Used by several plugins, to make builds reproducible -->
+		<project.build.outputTimestamp>2021-06-22T10:45:00Z</project.build.outputTimestamp>
 	</properties>
 	
 	<dependencies>
@@ -414,6 +416,7 @@
 			<plugin>
 			    <groupId>org.apache.maven.plugins</groupId>
 			    <artifactId>maven-jar-plugin</artifactId>
+				<version>3.2.0</version>
 			    <configuration>
 				<archive>
 				    <manifestEntries>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -102,7 +102,7 @@
 						</replacement>
 						<replacement>
 							<token>$buildTimestamp$</token>
-							<value>${maven.build.timestamp}</value>
+							<value>${project.build.outputTimestamp}</value>
 						</replacement>
 						<replacement>
 							<token>$buildNumber$</token>


### PR DESCRIPTION
Added [`maven-artifact-plugin`](https://maven.apache.org/plugins/maven-artifact-plugin/buildinfo-mojo.html) to create build information in `target/*.buildinfo` and compare whether Java archives created in two subsequent builds are bit-identical (only those with property `maven.deploy.skip=false`, thus, those that will be deployed on Maven Central). In case of differences, the build breaks in stage "Verify JavaDoc, Source and Reproducibility".