### PR TITLE
Fixed configuration of flatten and nexus plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,7 @@
 							<serverId>ossrh</serverId>
 							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
 							<autoReleaseAfterClose>true</autoReleaseAfterClose>
+							<skipNexusStagingDeployMojo>${maven.deploy.skip}</skipNexusStagingDeployMojo>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -429,7 +430,7 @@
 							<goal>flatten</goal>
 						</goals>
 						<configuration>
-							<flattenMode>clean</flattenMode>
+							<flattenMode>ossrh</flattenMode>
 						</configuration>
 					</execution>
 					<execution>


### PR DESCRIPTION
Configured the `flatten-maven-plugin` to keep POM elements required for uploads to Maven Central, and the `nexus-staging-maven-plugin` to skip the deployment of certain modules on Maven Central.