### PR TITLE
Updated json-path from 2.4 to 2.6 in order to update json-smart

### DIFF
--- a/kb-importer/pom.xml
+++ b/kb-importer/pom.xml
@@ -79,7 +79,7 @@
 		<dependency>
 			<groupId>com.jayway.jsonpath</groupId>
 			<artifactId>json-path</artifactId>
-			<version>2.4.0</version>
+			<version>2.6.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Updated json-path to get off a vulnerable version of json-smart