### PR TITLE
Updated org.apache.maven dependencies from 3.8.1 to 3.8.2

### DIFF
--- a/lang-java-reach-soot/pom.xml
+++ b/lang-java-reach-soot/pom.xml
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>de.tud.sse</groupId>
 			<artifactId>soot-infoflow</artifactId>
-			<version>2.8</version>
+			<version>2.9</version>
 			<scope>compile</scope>
 			<!-- Defined in its dependency on soot:3.2.0, which is any how irrelevant 
 				due to the above dep on soot:3.2.0 -->

--- a/lang-java-reach-soot/pom.xml
+++ b/lang-java-reach-soot/pom.xml
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>de.tud.sse</groupId>
 			<artifactId>soot-infoflow</artifactId>
-			<version>2.9</version>
+			<version>2.9.0</version>
 			<scope>compile</scope>
 			<!-- Defined in its dependency on soot:3.2.0, which is any how irrelevant 
 				due to the above dep on soot:3.2.0 -->

--- a/plugin-maven/pom.xml
+++ b/plugin-maven/pom.xml
@@ -80,6 +80,11 @@
             <artifactId>maven-plugin-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-cipher</artifactId>
+            <version>1.8</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.6.1</version>

--- a/plugin-maven/pom.xml
+++ b/plugin-maven/pom.xml
@@ -74,12 +74,10 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.8.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.8.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>

--- a/plugin-maven/pom.xml
+++ b/plugin-maven/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.10.10</version>
+            <version>1.10.11</version>
         </dependency>
 
         <!--instrumentation agent dependency -->

--- a/pom.xml
+++ b/pom.xml
@@ -386,17 +386,17 @@
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-core</artifactId>
-				<version>3.8.1</version>
+				<version>3.8.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-model</artifactId>
-				<version>3.8.1</version>
+				<version>3.8.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-plugin-api</artifactId>
-				<version>3.8.1</version>
+				<version>3.8.2</version>
 			</dependency>
 
 			<!-- Test deps -->


### PR DESCRIPTION
Updated org.apache.maven:* dependencies from 3.8.1 to 3.8.2, ant from 1.10.10 to 1.10.11, and soot-infoflow from 2.8 to 2.9.0.

The update of org.apache.maven resulted in a new dependency on org.codehaus.plexus:plexus-cipher 1.8, which replaces org.sonatype.plexus:plexus-cipher (a transitive dependency of org.apache.maven:maven-core 3.8.1 that has been [removed with version 3.8.2](https://github.com/apache/maven/commit/24da558d5a1714f5e2427ed73e8f139168128a30)).