### PR TITLE
Update vulnerable versions of log4j and ant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,12 +292,12 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.14.1</version>
+			<version>2.15.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.14.1</version>
+			<version>2.15.0</version>
 		</dependency>
 		<dependency>
   			<groupId>com.github.spotbugs</groupId>

--- a/rest-lib-utils/pom.xml
+++ b/rest-lib-utils/pom.xml
@@ -224,7 +224,7 @@
 		<dependency>
 			<groupId>org.apache.ant</groupId>
 			<artifactId>ant</artifactId>
-			<version>1.10.10</version>
+			<version>1.10.11</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Updated `org.apache.ant:ant` from version 1.10.10 to 1.10.11, as well as `log4j-api` and `log4j-core` from 1.14.1 to 1.15.0.

#### `TODO`s

- [ ] Tests
- [ ] Documentation