### PR TITLE
Update vulnerable version of guava

### DIFF
--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -183,7 +183,7 @@
 		<dependency>
 		    <groupId>com.google.guava</groupId>
 		    <artifactId>guava</artifactId>
-		    <version>28.2-jre</version>
+		    <version>30.0-jre</version>
 		</dependency>
 
 		<!-- Test dependencies -->


### PR DESCRIPTION
Updated `com.google.guava:guava` from vulnerable version 28.2-jre to fixed version 30.0-jre
