### PR TITLE
updated log4j to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,12 +292,12 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.15.0</version>
+			<version>2.16.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.15.0</version>
+			<version>2.16.0</version>
 		</dependency>
 		<dependency>
   			<groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
Updated log4j from vulnerable version 2.15.0 to 2.16.0