### PR TITLE
Change version in .env.sample and fix bump script

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -58,6 +58,7 @@ if [ -z $is_snap ]; then
   sed -i "" "s/${old_doc}/${new}/" docs/public.properties
   sed -i "" "s/${old_doc}/${new}/" docker/setup-steady.sh
   sed -i "" "s/${old_doc}/${new}/" docker/start-steady.sh
+  sed -i "" "s/${old_doc}/${new}/" docker/.env.sample
 fi
 
 # Kubernetes doc files

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -1,5 +1,5 @@
 # Eclipse Steady
-VULAS_RELEASE=3.2.0
+VULAS_RELEASE=3.2.2
 VULAS_ENV=prod
 
 # *** MANDATORY SETTINGS ***


### PR DESCRIPTION
Corrected version in `.env.sample`, which is taken by the setup script, and updated `bump-version.sh` to make sure this happens automatically in the future.

#### `TODO`s

- [ ] Tests
- [ ] Documentation