### PR TITLE
Updated Log4j from 2.17.0 to 2.17.1, changed scope of H2 from compile (default) to test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,12 +292,12 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.17.0</version>
+			<version>2.17.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.17.0</version>
+			<version>2.17.1</version>
 		</dependency>
 		<dependency>
   			<groupId>com.github.spotbugs</groupId>

--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -265,8 +265,9 @@
 				<dependency>
 					<groupId>com.h2database</groupId>
 					<artifactId>h2</artifactId>
-					<version>1.4.199</version><!-- Fix Spring Boot's dependency on vulnerable
+					<version>1.4.200</version><!-- Fix Spring Boot's dependency on vulnerable
 						h2 1.4.197 (org.springframework.boot:spring-boot-dependencies:1.5.19.RELEASE) -->
+					<scope>test</scope>
 				</dependency>
 				<dependency>
 					<groupId>org.postgresql</groupId>


### PR DESCRIPTION
Updated Log4j from 2.17.0 to 2.17.1, changed scope of H2 from compile (default) to test. 

#### `TODO`s

- [x] Tests
- [ ] Documentation