### PR TITLE
Updated deps, fixed bump-version.sh and deprec. API calls

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -42,7 +42,7 @@ fi
 # Build timestamp
 old_timestamp=`less pom.xml | grep -m 1 "<project.build.outputTimestamp>" | sed -n "s/.*<project.build.outputTimestamp>\(.*\)<\/project.build.outputTimestamp>.*/\1/p"`
 #new_timestamp=`date --utc --iso-8601=seconds`
-new_timestamp=`date -u "+%Y-%m-%dT%H:%M:%S%z"`
+new_timestamp=`date -u "+%Y-%m-%dT%H:%M:%S"`+00:00
 
 # Maven
 #find . -name pom.xml -exec sed -i "" "0,/${old}/s//${new}/" {} \;

--- a/lang-java-reach-soot/src/main/java/org/eclipse/steady/cg/soot/SootCallgraphConstructor.java
+++ b/lang-java-reach-soot/src/main/java/org/eclipse/steady/cg/soot/SootCallgraphConstructor.java
@@ -27,6 +27,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import com.ibm.wala.util.graph.Graph;
+import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
+
 import org.apache.commons.configuration.Configuration;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.steady.cg.CallgraphConstructException;
@@ -38,9 +41,6 @@ import org.eclipse.steady.java.monitor.ClassVisitor;
 import org.eclipse.steady.shared.json.model.Application;
 import org.eclipse.steady.shared.util.StringUtil;
 import org.eclipse.steady.shared.util.VulasConfiguration;
-
-import com.ibm.wala.util.graph.Graph;
-import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
 
 import soot.G;
 import soot.MethodOrMethodContext;
@@ -416,7 +416,7 @@ public class SootCallgraphConstructor implements ICallgraphConstructor {
       this.buildTimeNano = System.nanoTime() - start_nanos;
       SootCallgraphConstructor.log.info(
           "Construction completed in "
-              + StringUtil.nanoToMinString(this.buildTimeNano)
+              + StringUtil.nanoToFlexDurationString(this.buildTimeNano)
               + ", call graph has ["
               + callgraph.size()
               + "] edges]");

--- a/lang-python/src/main/java/org/eclipse/steady/python/Python335FileAnalyzer.java
+++ b/lang-python/src/main/java/org/eclipse/steady/python/Python335FileAnalyzer.java
@@ -31,7 +31,8 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.TreeMap;
 
-import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -42,12 +43,11 @@ import org.eclipse.steady.ConstructId;
 import org.eclipse.steady.FileAnalysisException;
 import org.eclipse.steady.FileAnalyzer;
 import org.eclipse.steady.FileAnalyzerFactory;
-import org.eclipse.steady.shared.util.FileUtil;
-import org.eclipse.steady.shared.util.StringUtil;
-
 import org.eclipse.steady.python.antlr.python335.Python335BaseListener;
 import org.eclipse.steady.python.antlr.python335.Python335Lexer;
 import org.eclipse.steady.python.antlr.python335.Python335Parser;
+import org.eclipse.steady.shared.util.FileUtil;
+import org.eclipse.steady.shared.util.StringUtil;
 
 // TODO: Decide what to do with default arg values in functions and methods? Right now, they are
 // part of the qname, which is probably wrong.
@@ -316,7 +316,7 @@ public class Python335FileAnalyzer extends Python335BaseListener implements File
    */
   public Map<ConstructId, Construct> getConstructs(InputStream m)
       throws FileAnalysisException, IOException, RecognitionException {
-    final ANTLRInputStream input = new ANTLRInputStream(m);
+    final CharStream input = CharStreams.fromStream(m);
     final Python335Lexer lexer = new Python335Lexer(input);
     final CommonTokenStream tokens = new CommonTokenStream(lexer);
     final Python335Parser parser = new Python335Parser(tokens);

--- a/lang-python/src/main/java/org/eclipse/steady/python/Python3FileAnalyzer.java
+++ b/lang-python/src/main/java/org/eclipse/steady/python/Python3FileAnalyzer.java
@@ -31,7 +31,8 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.TreeMap;
 
-import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -42,12 +43,11 @@ import org.eclipse.steady.ConstructId;
 import org.eclipse.steady.FileAnalysisException;
 import org.eclipse.steady.FileAnalyzer;
 import org.eclipse.steady.FileAnalyzerFactory;
-import org.eclipse.steady.shared.util.FileUtil;
-import org.eclipse.steady.shared.util.StringUtil;
-
 import org.eclipse.steady.python.antlr.python3.Python3BaseListener;
 import org.eclipse.steady.python.antlr.python3.Python3Lexer;
 import org.eclipse.steady.python.antlr.python3.Python3Parser;
+import org.eclipse.steady.shared.util.FileUtil;
+import org.eclipse.steady.shared.util.StringUtil;
 
 // TODO: Decide what to do with default arg values in functions and methods? Right now, they are
 // part of the qname, which is probably wrong.
@@ -316,7 +316,7 @@ public class Python3FileAnalyzer extends Python3BaseListener implements FileAnal
    */
   public Map<ConstructId, Construct> getConstructs(InputStream m)
       throws FileAnalysisException, IOException, RecognitionException {
-    final ANTLRInputStream input = new ANTLRInputStream(m);
+    final CharStream input = CharStreams.fromStream(m);
     final Python3Lexer lexer = new Python3Lexer(input);
     final CommonTokenStream tokens = new CommonTokenStream(lexer);
     final Python3Parser parser = new Python3Parser(tokens);

--- a/plugin-maven/pom.xml
+++ b/plugin-maven/pom.xml
@@ -82,24 +82,24 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-cipher</artifactId>
-            <version>1.8</version>
+            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.1</version>
+            <version>3.6.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.2.1</version>
+            <version>3.4.1</version>
         </dependency>
         <!-- use ant's commandline parser -->
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.10.11</version>
+            <version>1.10.12</version>
         </dependency>
 
         <!--instrumentation agent dependency -->
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
-            <version>3.6.3</version>
+            <version>3.8.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -138,7 +138,7 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-verifier</artifactId>
-            <version>1.6</version>
+            <version>1.7.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,6 @@
 	</distributionManagement>
 
 	<properties>
-		<!-- Leave at 1.7, otherwise the agent may not work with older applications -->
 		<maven.compiler.release>8</maven.compiler.release>
 		<maven.compiler.showWarnings>true</maven.compiler.showWarnings>
 		<maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
@@ -301,7 +300,7 @@
 		<dependency>
   			<groupId>com.github.spotbugs</groupId>
   			<artifactId>spotbugs-annotations</artifactId>
-  			<version>4.2.3</version>
+  			<version>4.5.3</version>
 		</dependency>
 	</dependencies>
 
@@ -346,7 +345,7 @@
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>2.8.7</version>
+				<version>2.8.9</version>
 			</dependency>
 			<dependency>
 				<groupId>org.javassist</groupId>
@@ -356,12 +355,12 @@
 			<dependency>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-runtime</artifactId>
-				<version>4.9.2</version>
+				<version>4.9.3</version>
 			</dependency>
 			<dependency>
 				<groupId>com.github.package-url</groupId>
 				<artifactId>packageurl-java</artifactId>
-				<version>1.3.0</version>
+				<version>1.4.1</version>
 			</dependency>
 
 			<!-- Versions of 'com.fasterxml.jackson.core' artifacts should be identical -->
@@ -760,7 +759,7 @@
 						<dependency>
 							<groupId>org.apache.maven.wagon</groupId>
 							<artifactId>wagon-file</artifactId>
-							<version>3.4.3</version>
+							<version>3.5.1</version>
 						</dependency>
 					</dependencies>
 				</plugin>

--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -217,7 +217,7 @@
 		<dependency>
 			<groupId>com.xebialabs.restito</groupId>
 			<artifactId>restito</artifactId>
-			<version>0.9.3</version>
+			<version>0.9.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/rest-lib-utils/pom.xml
+++ b/rest-lib-utils/pom.xml
@@ -224,7 +224,7 @@
 		<dependency>
 			<groupId>org.apache.ant</groupId>
 			<artifactId>ant</artifactId>
-			<version>1.10.11</version>
+			<version>1.10.12</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/shared/src/test/java/org/eclipse/steady/shared/model/IExemptionTest.java
+++ b/shared/src/test/java/org/eclipse/steady/shared/model/IExemptionTest.java
@@ -27,6 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import com.github.packageurl.MalformedPackageURLException;
+
 import org.eclipse.steady.shared.enums.Scope;
 import org.eclipse.steady.shared.json.JacksonUtil;
 import org.eclipse.steady.shared.json.model.ExemptionBug;
@@ -38,8 +40,6 @@ import org.eclipse.steady.shared.json.model.VulnerableDependency;
 import org.eclipse.steady.shared.util.FileUtil;
 import org.eclipse.steady.shared.util.VulasConfiguration;
 import org.junit.Test;
-
-import com.github.packageurl.MalformedPackageURLException;
 
 public class IExemptionTest {
 
@@ -338,7 +338,7 @@ public class IExemptionTest {
     } catch (MalformedPackageURLException e) {
       assertTrue(true);
       assertEquals(
-          "Package URLs of type [maven] require a valid namespace and name: [" + purl + "]",
+          "The PackageURL specified is invalid. Maven requires both a namespace and name.",
           e.getMessage());
     }
 


### PR DESCRIPTION
- Fixed the timezone offset in `bump-version.sh`, which caused some parsing problems down the line.
- Fixed calls of deprecated ANTLR APIs in `lang-python`.
- Updated minor and patch versions of several dependencies.

#### `TODO`s

- [x] Tests
- [ ] Documentation