### PR TITLE
Updated log4j, gson and json-path

### DIFF
--- a/kb-importer/pom.xml
+++ b/kb-importer/pom.xml
@@ -79,7 +79,7 @@
 		<dependency>
 			<groupId>com.jayway.jsonpath</groupId>
 			<artifactId>json-path</artifactId>
-			<version>2.6.0</version>
+			<version>2.7.0</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.7</version>
+				<version>2.11.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -290,12 +290,12 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.17.1</version>
+			<version>2.17.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.17.1</version>
+			<version>2.17.2</version>
 		</dependency>
 		<dependency>
   			<groupId>com.github.spotbugs</groupId>
@@ -345,7 +345,7 @@
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>2.8.9</version>
+				<version>2.9.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.javassist</groupId>

--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -158,7 +158,7 @@
 		<dependency>
 			<groupId>com.jayway.jsonpath</groupId>
 			<artifactId>json-path</artifactId>
-			<version>2.4.0</version>
+			<version>2.7.0</version>
 		</dependency>
 		
 		<!-- Swagger dependencies -->		


### PR DESCRIPTION
Updated log4j to 2.17.2 , gson to 2.9.0, commons-io to 2.11.0 and json-path to 2.7.0

#### `TODO`s

- [ ] Tests
- [ ] Documentation