### PR TITLE
Removed digest from instr. code for classes in BOOT-INF/classes

### DIFF
--- a/lang-java-reach-soot/src/main/java/org/eclipse/steady/cg/soot/SootCallgraphConstructor.java
+++ b/lang-java-reach-soot/src/main/java/org/eclipse/steady/cg/soot/SootCallgraphConstructor.java
@@ -234,11 +234,12 @@ public class SootCallgraphConstructor implements ICallgraphConstructor {
     }
 
     ArrayList<String> processDirs = new ArrayList<>();
-    final StringTokenizer tokenizer = new StringTokenizer(this.appClasspath, System.getProperty("path.separator"));
-    while(tokenizer.hasMoreTokens()) {
-       processDirs.add(tokenizer.nextToken());
+    final StringTokenizer tokenizer =
+        new StringTokenizer(this.appClasspath, System.getProperty("path.separator"));
+    while (tokenizer.hasMoreTokens()) {
+      processDirs.add(tokenizer.nextToken());
     }
-    
+
     Options.v().set_process_dir(processDirs);
     Options.v().set_soot_classpath(this.classpath);
   }

--- a/lang-java-reach-soot/src/main/java/org/eclipse/steady/cg/soot/SootCallgraphConstructor.java
+++ b/lang-java-reach-soot/src/main/java/org/eclipse/steady/cg/soot/SootCallgraphConstructor.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.StringTokenizer;
 
 import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
@@ -74,14 +75,12 @@ public class SootCallgraphConstructor implements ICallgraphConstructor {
 
   private VulasConfiguration vulasConfiguration = null;
 
-  /**
-   * The JAR to be analyzed.
-   */
-  // private String appJar = null;
   protected String classpath = null;
 
   private String appClasspath = null;
+
   protected final List<SootMethod> entrypoints = new ArrayList<>();
+
   private final Set<org.eclipse.steady.shared.json.model.ConstructId> filteredEP = new HashSet<>();
 
   private CallGraph callgraph = null;
@@ -133,7 +132,9 @@ public class SootCallgraphConstructor implements ICallgraphConstructor {
     if (this.classpath != null) {
       this.classpath += System.getProperty("path.separator");
       this.classpath += _cp;
-    } else this.classpath = _cp;
+    } else {
+      this.classpath = _cp;
+    }
     this.appClasspath = _cp;
 
     SootCallgraphConstructor.log.info(
@@ -233,9 +234,12 @@ public class SootCallgraphConstructor implements ICallgraphConstructor {
     }
 
     ArrayList<String> processDirs = new ArrayList<>();
-    processDirs.add(this.appClasspath);
+    final StringTokenizer tokenizer = new StringTokenizer(this.appClasspath, System.getProperty("path.separator"));
+    while(tokenizer.hasMoreTokens()) {
+       processDirs.add(tokenizer.nextToken());
+    }
+    
     Options.v().set_process_dir(processDirs);
-
     Options.v().set_soot_classpath(this.classpath);
   }
 

--- a/lang-java/src/main/java/org/eclipse/steady/java/SpringBootAnalyzer.java
+++ b/lang-java/src/main/java/org/eclipse/steady/java/SpringBootAnalyzer.java
@@ -405,8 +405,8 @@ public class SpringBootAnalyzer extends JarAnalyzer {
             // Instrument (if requested and not blacklisted)
             if (this.instrument && !this.instrControl.isBlacklistedClass(cn)) {
               // The SpringBoot JAR itself is not a dependency, hence, we do not set the digest
-              //cv.setOriginalArchiveDigest(this.getSHA1());
-              
+              // cv.setOriginalArchiveDigest(this.getSHA1());
+
               cv.setAppContext(SpringBootAnalyzer.getAppContext());
               if (cv.isInstrumented())
                 this.instrControl.updateInstrumentationStatistics(cv.getJavaId(), null);

--- a/lang-java/src/main/java/org/eclipse/steady/java/SpringBootAnalyzer.java
+++ b/lang-java/src/main/java/org/eclipse/steady/java/SpringBootAnalyzer.java
@@ -404,7 +404,9 @@ public class SpringBootAnalyzer extends JarAnalyzer {
 
             // Instrument (if requested and not blacklisted)
             if (this.instrument && !this.instrControl.isBlacklistedClass(cn)) {
-              cv.setOriginalArchiveDigest(this.getSHA1());
+              // The SpringBoot JAR itself is not a dependency, hence, we do not set the digest
+              //cv.setOriginalArchiveDigest(this.getSHA1());
+              
               cv.setAppContext(SpringBootAnalyzer.getAppContext());
               if (cv.isInstrumented())
                 this.instrControl.updateInstrumentationStatistics(cv.getJavaId(), null);
@@ -559,7 +561,7 @@ public class SpringBootAnalyzer extends JarAnalyzer {
             "No instrumented class found for Jar Entry [" + _entry.getName() + "]");
       }
     }
-    // Called during rewrite of WAR
+    // Called during rewrite of JARs
     else if (_regex.equals("^BOOT-INF/lib/.*.jar$")) {
       JarAnalyzer ja = null;
       try {

--- a/lang-java/src/main/java/org/eclipse/steady/java/WarAnalyzer.java
+++ b/lang-java/src/main/java/org/eclipse/steady/java/WarAnalyzer.java
@@ -372,8 +372,8 @@ public class WarAnalyzer extends JarAnalyzer {
             // Instrument (if requested and not blacklisted)
             if (this.instrument && !this.instrControl.isBlacklistedClass(cn)) {
               // The WAR itself is not a dependency, hence, we do not set the digest
-              //cv.setOriginalArchiveDigest(this.getSHA1());
-              
+              // cv.setOriginalArchiveDigest(this.getSHA1());
+
               cv.setAppContext(WarAnalyzer.getAppContext());
               if (cv.isInstrumented())
                 this.instrControl.updateInstrumentationStatistics(cv.getJavaId(), null);

--- a/lang-java/src/main/java/org/eclipse/steady/java/WarAnalyzer.java
+++ b/lang-java/src/main/java/org/eclipse/steady/java/WarAnalyzer.java
@@ -371,7 +371,9 @@ public class WarAnalyzer extends JarAnalyzer {
 
             // Instrument (if requested and not blacklisted)
             if (this.instrument && !this.instrControl.isBlacklistedClass(cn)) {
-              cv.setOriginalArchiveDigest(this.getSHA1());
+              // The WAR itself is not a dependency, hence, we do not set the digest
+              //cv.setOriginalArchiveDigest(this.getSHA1());
+              
               cv.setAppContext(WarAnalyzer.getAppContext());
               if (cv.isInstrumented())
                 this.instrControl.updateInstrumentationStatistics(cv.getJavaId(), null);

--- a/lang/src/main/java/org/eclipse/steady/goals/AbstractGoal.java
+++ b/lang/src/main/java/org/eclipse/steady/goals/AbstractGoal.java
@@ -410,7 +410,7 @@ public abstract class AbstractGoal implements Runnable {
 
     // Monitor mem consumption?
     if (this.memoThread != null) {
-      final Thread t = new Thread(this.memoThread, "vulas-memo");
+      final Thread t = new Thread(this.memoThread, "memo");
       t.setPriority(Thread.MIN_PRIORITY);
       t.start();
     }


### PR DESCRIPTION
Java classes below `WEB-INF/classes` in a WAR and below `BOOT-INF/classes` in a Spring-Boot JAR are considered belonging to the application under analysis. For this reason, the digest of the WAR and JAR respectively will not be included in the instrumentation code. This digest should only be set for code in dependencies.

#### `TODO`s

- [ ] Tests
- [ ] Documentation