### PR TITLE
Avoid unecessary operations in kb-importer

### DIFF
--- a/kb-importer/src/main/java/org/eclipse/steady/kb/command/Import.java
+++ b/kb-importer/src/main/java/org/eclipse/steady/kb/command/Import.java
@@ -115,6 +115,27 @@ public class Import implements Command {
       Import.log.error("Please specify the vulerability id in the json");
       return;
     }
+        
+    String vulnId = vuln.getVulnId();
+    boolean bugExists = false;
+    try {
+      bugExists = BackendConnector.getInstance().isBugExisting(vulnId);
+    }
+    catch (BackendConnectionException e) {
+      log.error("Can't connect to the Backend");
+      return;
+    }
+
+    Boolean overwrite = (Boolean) args.get(OVERWRITE_OPTION);
+    if (bugExists) {
+      if (overwrite) {
+        args.put(DELETE, true);
+      }
+      else {
+        log.info("Bug [{}] already exists in backend, analysis will be skipped", vulnId);
+        return;
+      }
+    }
 
     List<Task> importTasks = TaskProvider.getInstance().getTasks(Command.NAME.IMPORT);
 

--- a/kb-importer/src/main/java/org/eclipse/steady/kb/task/ImportAffectedLibraries.java
+++ b/kb-importer/src/main/java/org/eclipse/steady/kb/task/ImportAffectedLibraries.java
@@ -46,6 +46,7 @@ import com.github.packageurl.PackageURL;
  */
 public class ImportAffectedLibraries implements Task {
   private static final String OVERWRITE_OPTION = "o";
+  private static final String DELETE = "del";
   private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
   /** {@inheritDoc} */
@@ -55,6 +56,9 @@ public class ImportAffectedLibraries implements Task {
     List<Artifact> artifacts = vuln.getArtifacts();
     if (artifacts == null || artifacts.isEmpty()) {
       return;
+    }
+    if ((boolean) args.get(DELETE)) {
+      backendConnector.deletePatchEvalResults(vuln.getVulnId(), AffectedVersionSource.KAYBEE);
     }
 
     List<AffectedLibrary> affectedLibsToUpsert = new ArrayList<AffectedLibrary>();

--- a/kb-importer/src/main/java/org/eclipse/steady/kb/task/ImportVulnerability.java
+++ b/kb-importer/src/main/java/org/eclipse/steady/kb/task/ImportVulnerability.java
@@ -56,6 +56,7 @@ public class ImportVulnerability implements Task {
   private static final String OVERWRITE_OPTION = "o";
   private static final String DIRECTORY_OPTION = "d";
   private static final String VERBOSE_OPTION = "v";
+  private static final String DELETE = "del";
 
   private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
   private BackendConnector backendConnector = null;
@@ -67,10 +68,9 @@ public class ImportVulnerability implements Task {
     String vulnId = vuln.getVulnId();
     this.backendConnector = _backendConnector;
 
-    Boolean overwrite = (Boolean) args.get(OVERWRITE_OPTION);
-    if (!overwrite && getBackendConnector().isBugExisting(vulnId)) {
-      log.info("Bug [{}] already exists in backend, analysis will be skipped", vulnId);
-      return;
+    if ((boolean) args.get(DELETE)) {
+      backendConnector.deleteBug(vuln.getVulnId());
+      log.info(vuln.getVulnId());
     }
 
     List<Commit> commits = new ArrayList<Commit>();

--- a/lang/src/main/java/org/eclipse/steady/backend/BackendConnector.java
+++ b/lang/src/main/java/org/eclipse/steady/backend/BackendConnector.java
@@ -1042,6 +1042,22 @@ public class BackendConnector {
   }
 
   /**
+   * <p>deleteBug.</p>
+   *
+   * @param _bugId a {@link java.lang.String} object.
+   * @throws org.eclipse.steady.backend.BackendConnectionException if any.
+   */
+  public void deleteBug(String _bugId) throws BackendConnectionException {
+
+    final BasicHttpRequest del_req =
+        new BasicHttpRequest(HttpMethod.DELETE, 
+        PathBuilder.bug(_bugId));
+    // payload cannot be empty otherwise request doesn t work
+    del_req.setPayload("[]", "application/json", true);
+    del_req.send();
+  }
+
+  /**
    * <p>uploadCheckVersionResults.</p>
    *
    * @param _bugId a {@link java.lang.String} object.


### PR DESCRIPTION
Avoid uploading the affected libraries and construct changes when they are already present in the backend.
Delete affected libraries and constructs changes before uploading if the overwrite option is used,

#### `TODO`s

- [ ] Tests
- [ ] Documentation