### PR TITLE
New "Bloat" tab in frontend-apps

### DIFF
--- a/frontend-apps/src/main/webapp/i18n/messageBundle.properties
+++ b/frontend-apps/src/main/webapp/i18n/messageBundle.properties
@@ -38,6 +38,7 @@ masterCreateSpaceTooltip=Create workspace
 
 
 Archives=Dependencies
+Bloat=Bloat
 patchAnalysis=Vulnerabilities
 mavenVerified=Maven-verified archive
 testCoverageTitle=Testcoverage for 

--- a/frontend-apps/src/main/webapp/model/Formatter.js
+++ b/frontend-apps/src/main/webapp/model/Formatter.js
@@ -239,6 +239,12 @@ model.Formatter = {
 		return a;
 	},
 	
+	debloat: function(reach,traced,exec){
+		if( reach==0 && traced==0 && exec>0)
+			return true;
+		else return false;
+	},
+	
 	parentDepth : function(parent) {
 		let a=0;
 		if(parent){

--- a/frontend-apps/src/main/webapp/view/Component.controller.js
+++ b/frontend-apps/src/main/webapp/view/Component.controller.js
@@ -104,6 +104,7 @@ sap.ui.controller("view.Component", {
 		archiveTraced.setText("Archives Traced: " + traced);
 		archiveReachable.setText("Archives Reachable: " + reachable);
 		archiveTotalTraces.setText("Total Number of Traces: " + traces);
+		
 	},
 	
 //	includeTestDeps: function(){
@@ -172,11 +173,12 @@ sap.ui.controller("view.Component", {
 			});
 
 			this.getView().byId("idBloatList").getBinding("rows").filter(tableFilter);
-	
 		}
-	
-		else
+		else{
 			this.getView().byId("idBloatList").getBinding("rows").filter();
+		}
+		this.getView().byId("idBloatList").setVisibleRowCount(this.getView().byId("idBloatList").getBinding("rows").iLength);
+		
 	},
 	
 	// Vulnerabilities tab: Sets the 2 counters
@@ -466,7 +468,6 @@ sap.ui.controller("view.Component", {
 				oArchiveView.setModel(oArchiveModel);
 				oArchiveView.setBusy(false);
 
-				oBloatView.setVisibleRowCount(oArchiveModel.getObject("/").length);
 				oBloatView.setModel(oArchiveModel);
 				scopeColumn.setFilterValue("!=TEST");
 				scopeColumn.setFiltered(true);

--- a/frontend-apps/src/main/webapp/view/Component.view.xml
+++ b/frontend-apps/src/main/webapp/view/Component.view.xml
@@ -380,7 +380,7 @@
 									</m:MatrixLayoutRow>
 									<m:MatrixLayoutRow>
 										<m:MatrixLayoutCell>
-											<CheckBox id="showDebloat" text="Show Debloatable" selected="false" select="showDebloatableArchives"/>
+											<CheckBox id="showDebloat" text="Show debloatable only (libraries with executable constructs where none was actually executed nor found potentially reachable)" selected="false" select="showDebloatableArchives"/>
 										</m:MatrixLayoutCell>
 									</m:MatrixLayoutRow>
 								</m:MatrixLayout>
@@ -452,7 +452,7 @@
 										</template>
 									</Column>
 									<Column xmlns="sap.ui.table" width="10%" >
-											<Label text="Debloat? " xmlns="sap.ui.commons" />
+											<Label text="Debloatable? " xmlns="sap.ui.commons" />
 										<template>
 												<TextView xmlns="sap.ui.commons"
 												text="{

--- a/frontend-apps/src/main/webapp/view/Component.view.xml
+++ b/frontend-apps/src/main/webapp/view/Component.view.xml
@@ -333,6 +333,15 @@
 										</template>
 										<!-- Text text="App actually executes library code" / -->
 									</Column>
+									<Column xmlns="sap.ui.table" width="10%" sorted="true">
+										<multiLabels>
+											<Label text="Library executable " xmlns="sap.ui.commons" />
+											<Label text="constructs" xmlns="sap.ui.commons" />
+										</multiLabels>
+										<template>
+											<TextView xmlns="sap.ui.commons" text="{lib/constructTypeCounters/countExecutable}"></TextView>
+										</template>
+									</Column>
 								</Table>
 							</IconTabFilter>
 

--- a/frontend-apps/src/main/webapp/view/Component.view.xml
+++ b/frontend-apps/src/main/webapp/view/Component.view.xml
@@ -249,14 +249,14 @@
 										</template>
 									</Column>
 									<Column xmlns="sap.ui.table" width="10%" sorted="true"
-										sortProperty="scope">
+										sortProperty="scope" filterProperty="scope">
 										<Label text="Dependency Scope" xmlns="sap.ui.commons" />
 										<template>
 											<TextView xmlns="sap.ui.commons" text="{scope}"></TextView>
 										</template>
 									</Column>
 									<Column xmlns="sap.ui.table" width="10%" sorted="true"
-										sortProperty="transitive">
+										sortProperty="transitive" filterProperty="transitive">
 										<Label text="Direct / Transitive" xmlns="sap.ui.commons" />
 										<template>
 											<TextView xmlns="sap.ui.commons"

--- a/frontend-apps/src/main/webapp/view/Component.view.xml
+++ b/frontend-apps/src/main/webapp/view/Component.view.xml
@@ -219,16 +219,16 @@
 											<Text id="archiveTotal" xmlns="sap.m" text="None" />
 										</m:MatrixLayoutCell>
 									</m:MatrixLayoutRow>
-									<m:MatrixLayoutRow>
-										<m:MatrixLayoutCell>
-											<Text id="archiveTraced" xmlns="sap.m" text="None" />
-										</m:MatrixLayoutCell>
-									</m:MatrixLayoutRow>
-									<m:MatrixLayoutRow>
-										<m:MatrixLayoutCell>
-											<Text id="archiveTotalTraces" xmlns="sap.m" text="None" />
-										</m:MatrixLayoutCell>
-									</m:MatrixLayoutRow>
+<!-- 									<m:MatrixLayoutRow> -->
+<!-- 										<m:MatrixLayoutCell> -->
+<!-- 											<Text id="archiveTraced" xmlns="sap.m" text="None" /> -->
+<!-- 										</m:MatrixLayoutCell> -->
+<!-- 									</m:MatrixLayoutRow> -->
+<!-- 									<m:MatrixLayoutRow> -->
+<!-- 										<m:MatrixLayoutCell> -->
+<!-- 											<Text id="archiveTotalTraces" xmlns="sap.m" text="None" /> -->
+<!-- 										</m:MatrixLayoutCell> -->
+<!-- 									</m:MatrixLayoutRow> -->
 									<m:MatrixLayoutRow>
 										<m:MatrixLayoutCell>
 											<Text id="archiveAvgAge" xmlns="sap.m" text="None" />
@@ -310,8 +310,114 @@
 											</commons:TextView>
 										</template>
 									</Column>
+<!-- 									<Column xmlns="sap.ui.table" width="10%" sorted="true" -->
+<!-- 										sortProperty="reachExecConstructsCounter"> -->
+<!-- 										Text text="App potentially executes library code" / -->
+<!-- 										<multiLabels> -->
+<!-- 											<Label text="Library constructs" xmlns="sap.ui.commons" /> -->
+<!-- 											<Label text="potentially executable" xmlns="sap.ui.commons" /> -->
+<!-- 										</multiLabels> -->
+<!-- 										<template> -->
+<!-- 											<TextView xmlns="sap.ui.commons" -->
+<!-- 												text="{reachExecConstructsCounter}"></TextView> -->
+<!-- 										</template> -->
+<!-- 									</Column> -->
+<!-- 									<Column xmlns="sap.ui.table" width="10%" sorted="true" -->
+<!-- 										sortProperty="tracedExecConstructsCounter"> -->
+<!-- 										<multiLabels> -->
+<!-- 											<Label text="Library constructs " xmlns="sap.ui.commons" /> -->
+<!-- 											<Label text="actually executed" xmlns="sap.ui.commons" /> -->
+<!-- 										</multiLabels> -->
+<!-- 										<template> -->
+<!-- 											<TextView xmlns="sap.ui.commons" text="{tracedExecConstructsCounter}"></TextView> -->
+<!-- 										</template> -->
+<!-- 										Text text="App actually executes library code" / -->
+<!-- 									</Column> -->
+<!-- 									<Column xmlns="sap.ui.table" width="10%" sorted="true"> -->
+<!-- 										<multiLabels> -->
+<!-- 											<Label text="Library executable " xmlns="sap.ui.commons" /> -->
+<!-- 											<Label text="constructs" xmlns="sap.ui.commons" /> -->
+<!-- 										</multiLabels> -->
+<!-- 										<template> -->
+<!-- 											<TextView xmlns="sap.ui.commons" text="{lib/constructTypeCounters/countExecutable}"></TextView> -->
+<!-- 										</template> -->
+<!-- 									</Column> -->
+								</Table>
+							</IconTabFilter>
+
+							<IconTabFilter text="{i18n>Bloat}" icon="sap-icon://scissors" id="id_debloat">
+
+								<m:MatrixLayout columns="1">
+									<m:MatrixLayoutRow>
+										<m:MatrixLayoutCell>
+											<Text id="archiveInScope" xmlns="sap.m" text="None" />
+										</m:MatrixLayoutCell>
+									</m:MatrixLayoutRow>
+									<m:MatrixLayoutRow>
+										<m:MatrixLayoutCell>
+											<Text id="archiveDebloat" xmlns="sap.m" text="None" />
+										</m:MatrixLayoutCell>
+									</m:MatrixLayoutRow>
+									<m:MatrixLayoutRow>
+										<m:MatrixLayoutCell>
+											<Text id="archiveTraced" xmlns="sap.m" text="None" />
+										</m:MatrixLayoutCell>
+									</m:MatrixLayoutRow>
+									<m:MatrixLayoutRow>
+										<m:MatrixLayoutCell>
+											<Text id="archiveReachable" xmlns="sap.m" text="None" />
+										</m:MatrixLayoutCell>
+									</m:MatrixLayoutRow>
+									<m:MatrixLayoutRow>
+										<m:MatrixLayoutCell>
+											<Text id="archiveTotalTraces" xmlns="sap.m" text="None" />
+										</m:MatrixLayoutCell>
+									</m:MatrixLayoutRow>
+									<m:MatrixLayoutRow>
+									<m:MatrixLayoutCell>
+											<CheckBox id="includeTest" text="Include TEST dependencies" selected="false" select="showDebloatableArchives"/>
+										</m:MatrixLayoutCell>
+									</m:MatrixLayoutRow>
+									<m:MatrixLayoutRow>
+										<m:MatrixLayoutCell>
+											<CheckBox id="showDebloat" text="Show Debloatable" selected="false" select="showDebloatableArchives"/>
+										</m:MatrixLayoutCell>
+									</m:MatrixLayoutRow>
+								</m:MatrixLayout>
+
+
+								<Table xmlns="sap.ui.table" id="idBloatList"
+									rows="{ path: '/', sorter: { path: 'filename'} }"
+									selectionMode="None">
+									<Column xmlns="sap.ui.table" width="30%" sorted="true"
+										filtered="true" sortProperty="filename" filterProperty="filename">
+										<Label text="Archive Filename&#13;&#10;(Digest)" xmlns="sap.ui.commons" />
+										<template>
+											<ObjectIdentifier title="{filename}" text="{lib/digest}"
+												xmlns="sap.m" titleActive="true" titlePress="onArchiveListItemTap" />
+										</template>
+									</Column>
 									<Column xmlns="sap.ui.table" width="10%" sorted="true"
-										sortProperty="reachExecConstructsCounter">
+										sortProperty="scope" filterProperty="scope" id='scopeColumn'>
+										<Label text="Dependency Scope" xmlns="sap.ui.commons" />
+										<template>
+											<TextView xmlns="sap.ui.commons" text="{scope}"></TextView>
+										</template>
+									</Column>
+									<Column xmlns="sap.ui.table" width="10%" sorted="true"
+										sortProperty="transitive" filterProperty="transitive">
+										<Label text="Direct / Transitive" xmlns="sap.ui.commons" />
+										<template>
+											<TextView xmlns="sap.ui.commons"
+												text="{
+		 												path: 'transitive',
+		 												formatter: 'model.Formatter.directTransitive'}"></TextView>
+										</template>
+									</Column>
+									<Column xmlns="sap.ui.table" width="10%" sorted="true"
+										sortProperty="reachExecConstructsCounter" 
+										filterProperty="reachExecConstructsCounter" filtered="false">
+										
 										<!-- Text text="App potentially executes library code" / -->
 										<multiLabels>
 											<Label text="Library constructs" xmlns="sap.ui.commons" />
@@ -323,7 +429,8 @@
 										</template>
 									</Column>
 									<Column xmlns="sap.ui.table" width="10%" sorted="true"
-										sortProperty="tracedExecConstructsCounter">
+										sortProperty="tracedExecConstructsCounter"
+										filterProperty="tracedExecConstructsCounter" filtered="false">
 										<multiLabels>
 											<Label text="Library constructs " xmlns="sap.ui.commons" />
 											<Label text="actually executed" xmlns="sap.ui.commons" />
@@ -333,13 +440,24 @@
 										</template>
 										<!-- Text text="App actually executes library code" / -->
 									</Column>
-									<Column xmlns="sap.ui.table" width="10%" sorted="true">
+									<Column xmlns="sap.ui.table" width="10%" sorted="true"
+									    sortProperty="lib/constructTypeCounters/countExecutable"
+									    filterProperty="lib/constructTypeCounters/countExecutable" filtered="false">
 										<multiLabels>
 											<Label text="Library executable " xmlns="sap.ui.commons" />
 											<Label text="constructs" xmlns="sap.ui.commons" />
 										</multiLabels>
 										<template>
 											<TextView xmlns="sap.ui.commons" text="{lib/constructTypeCounters/countExecutable}"></TextView>
+										</template>
+									</Column>
+									<Column xmlns="sap.ui.table" width="10%" >
+											<Label text="Debloat? " xmlns="sap.ui.commons" />
+										<template>
+												<TextView xmlns="sap.ui.commons"
+												text="{
+		 												parts: ['reachExecConstructsCounter','tracedExecConstructsCounter','lib/constructTypeCounters/countExecutable'],
+		 												formatter: 'model.Formatter.debloat'}"></TextView>
 										</template>
 									</Column>
 								</Table>

--- a/rest-backend/src/main/java/org/eclipse/steady/backend/model/Library.java
+++ b/rest-backend/src/main/java/org/eclipse/steady/backend/model/Library.java
@@ -461,7 +461,7 @@ public class Library implements Serializable {
    * @return a {@link org.eclipse.steady.backend.model.ConstructIdFilter} object.
    */
   @JsonProperty(value = "constructTypeCounters")
-  @JsonView(Views.CountDetails.class)
+  @JsonView(Views.Default.class)
   @JsonIgnoreProperties(
       value = {"constructTypeCounters"},
       allowGetters = true)


### PR DESCRIPTION
Added new IconTab to frontend-apps to be used for debloating the application (i.e., identify dependencies which are not "needed", aka which are bloated, and can thus be removed to reduce the attack surface).
In particular :
- it contains the information about libraries usages (which was previously in the "dependencies" tab")
- it shows candidate debloatable libraries, i.e.,  libraries with executable constructs where none was found potentially or actually reachable.

#### `TODO`s

- [x] Tests
- [ ] Documentation