### PR TITLE
Consider .flattened-pom.xml in plugin-gradle

### DIFF
--- a/lang-java-reach-soot/pom.xml
+++ b/lang-java-reach-soot/pom.xml
@@ -57,9 +57,9 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>de.tud.sse</groupId>
+			<groupId>de.fraunhofer.sit.sse.flowdroid</groupId>
 			<artifactId>soot-infoflow</artifactId>
-			<version>2.9.0</version>
+			<version>2.10.0</version>
 			<scope>compile</scope>
 			<!-- Defined in its dependency on soot:3.2.0, which is any how irrelevant 
 				due to the above dep on soot:3.2.0 -->

--- a/pom.xml
+++ b/pom.xml
@@ -429,6 +429,7 @@
 						</goals>
 						<configuration>
 							<flattenMode>ossrh</flattenMode>
+							<updatePomFile>true</updatePomFile>
 						</configuration>
 					</execution>
 					<execution>


### PR DESCRIPTION
The deployment of module `plugin-gradle` did not consider the `.flattend-pom.xml` but the original `pom.xml`, which references the parent module. Since that is not deployed to Maven Central, the Gradle plugin did not work (also see #541).

#### `TODO`s

- [ ] Tests
- [ ] Documentation