### PR TITLE
Updated push-images.sh and Docker-related documentation

### DIFF
--- a/docker/push-images.sh
+++ b/docker/push-images.sh
@@ -14,9 +14,9 @@ set -e
 usage () {
     cat <<HELP_USAGE
 Usage: $0 [options...]
- -r, --registry <registry>  The Docker registry.  e.g.: docker.io
- -p, --project <project>    The project where to nest it.  e.g.: vulas
- -v, --version <version>    The version of the images to push.  e.g.: 3.1.5
+ -r, --registry <registry>  The Docker registry (e.g., docker.io)
+ -p, --project <project>    The project or user where to nest it (e.g., eclipse)
+ -v, --version <version>    The version of the images to push (e.g., 3.1.5)
  -h, --help                 This help text
 HELP_USAGE
     exit 0
@@ -28,14 +28,14 @@ then
     exit 1
 fi
 
-set -- $options
+#set -- $options
 
 while true; do
     case "$1" in
         -r | --registry ) REGISTRY="$2"; shift 2 ;;
         -p | --project ) PROJECT="$2"; shift 2 ;;
         -v | --version ) VULAS_RELEASE="$2"; shift 2 ;;
-        -h | --help ) usage; shift 2 ;;
+        -h | --help ) usage; shift 1 ;;
         -- ) shift; break ;;
         * ) break ;;
     esac
@@ -56,7 +56,7 @@ if [[ ! $VULAS_RELEASE =~ $RELEASE_PATTERN ]]; then
     exit 1
 fi
 
-SERVICES='frontend-apps frontend-bugs patch-lib-analyzer rest-backend rest-lib-utils kb-importer pipeline'
+SERVICES='frontend-apps frontend-bugs patch-lib-analyzer rest-backend rest-lib-utils kb-importer'
 
 VULAS_RELEASE=${VULAS_RELEASE} docker-compose -f docker-compose.build.yml build
 
@@ -64,7 +64,6 @@ if [[ "$(docker images -q steady-rest-backend:"$VULAS_RELEASE" 2> /dev/null)" ==
     echo "[-] There are no local images for release $VULAS_RELEASE"
     exit 1
 fi
-
 
 for service in $SERVICES ; do
     IMAGE=${REGISTRY}/${PROJECT}/steady-${service}

--- a/docs/public/content/admin/tutorials/build.md
+++ b/docs/public/content/admin/tutorials/build.md
@@ -13,7 +13,7 @@ All the following commands are supposed to be executed from the root folder of t
 If you want to build images specific to a version you can checkout a stable version of Steady. Usually the `master` branch holds a `-SNAPSHOT` version.
 
 ```sh
-git checkout tags/@@PROJECT_VERSION@@
+git checkout tags/release-@@PROJECT_VERSION@@
 ```
 
 Make a copy of the sample configuration:

--- a/docs/public/content/admin/tutorials/registry.md
+++ b/docs/public/content/admin/tutorials/registry.md
@@ -35,7 +35,7 @@ Invoke the script with the following positional arguments.
 
 ```sh
 docker login [registry]
-bash push-images.sh -r [registry] -u [username] -v [steady-version]
+bash push-images.sh -r [registry] -p [project] -v [steady-version]
 ```
 
 ## Pulling the images from a repository
@@ -43,7 +43,7 @@ bash push-images.sh -r [registry] -u [username] -v [steady-version]
 You can use Docker to pull your images from a registry.
 
 ```sh
-docker pull [registry]/[username]/steady-rest-backend:[steady-version]
+docker pull [registry]/[project]/steady-rest-backend:[steady-version]
 ```
 
 ---


### PR DESCRIPTION
Updated `push-images.sh`, which uploads Docker images to arbitrary registries, and related documentation