### PR TITLE
Generate CycloneDX SBOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -697,6 +697,19 @@
 					</execution>
 				</executions>
 			</plugin>
+			
+			<plugin>
+					<groupId>org.cyclonedx</groupId>
+					<artifactId>cyclonedx-maven-plugin</artifactId>
+					<version>2.6.2</version>
+					<executions>
+					<execution>
+						<phase>package</phase>
+						<goals><goal>makeAggregateBom</goal></goals>
+					</execution>
+					</executions>
+			</plugin>
+
 
 		</plugins>
 


### PR DESCRIPTION
OWASP CycloneDX is a lightweight Software Bill of Materials (SBOM) standard designed to use in the application security contexts and supply chain component analysis. CycloneDX is an OWASP flagship project ( [owasp.org/www-project-cyclonedx](https://owasp.org/www-project-cyclonedx) ). The Open Web Application Security Project is a non-profit foundation that works to improve the security of software. CycloneDX is already supported by many security vendors and projects ( [cyclonedx.org/about/supporters](https://cyclonedx.org/about/supporters) ). It is also recommended in the Technology Radar Volume 26 ( [thoughtworks.com/radar/platforms?blipid=202203034](https://www.thoughtworks.com/radar/platforms?blipid=202203034) )

More details about the plugin : https://github.com/CycloneDX/cyclonedx-maven-plugin#maven-usage