### PR TITLE
Upgrade Docker images and fixes digest

### DIFF
--- a/docker/frontend-apps/Dockerfile
+++ b/docker/frontend-apps/Dockerfile
@@ -1,4 +1,5 @@
-FROM jetty:alpine
+# https://hub.docker.com/layers/jetty/library/jetty/9.4.46-jdk11-alpine-eclipse-temurin/images/sha256-dcaab143043b8916675f8533700c07310986e94db9ee4f2f6bf336e8befc53e9?context=explore
+FROM jetty@sha256:dcaab143043b8916675f8533700c07310986e94db9ee4f2f6bf336e8befc53e9
 
 LABEL maintainer="steady-dev@eclipse.org"
 

--- a/docker/frontend-bugs/Dockerfile
+++ b/docker/frontend-bugs/Dockerfile
@@ -1,4 +1,5 @@
-FROM jetty:alpine
+# https://hub.docker.com/layers/jetty/library/jetty/9.4.46-jdk11-alpine-eclipse-temurin/images/sha256-dcaab143043b8916675f8533700c07310986e94db9ee4f2f6bf336e8befc53e9?context=explore
+FROM jetty@sha256:dcaab143043b8916675f8533700c07310986e94db9ee4f2f6bf336e8befc53e9
 
 LABEL maintainer="steady-dev@eclipse.org"
 

--- a/docker/kb-importer/Dockerfile
+++ b/docker/kb-importer/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:11-jre-slim
+# https://hub.docker.com/layers/eclipse-temurin/library/eclipse-temurin/11.0.15_10-jre/images/sha256-1543416e05e9fde8ffede76cd5f0955b640d7159bdbff8574eed6560a98e4ad3?context=explore
+FROM eclipse-temurin@sha256:1543416e05e9fde8ffede76cd5f0955b640d7159bdbff8574eed6560a98e4ad3
 
 LABEL maintainer="steady-dev@eclipse.org"
 

--- a/docker/patch-lib-analyzer/Dockerfile
+++ b/docker/patch-lib-analyzer/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:11-jre-slim
+# https://hub.docker.com/layers/eclipse-temurin/library/eclipse-temurin/11.0.15_10-jre/images/sha256-1543416e05e9fde8ffede76cd5f0955b640d7159bdbff8574eed6560a98e4ad3?context=explore
+FROM eclipse-temurin@sha256:1543416e05e9fde8ffede76cd5f0955b640d7159bdbff8574eed6560a98e4ad3
 
 LABEL maintainer="steady-dev@eclipse.org"
 
@@ -10,9 +11,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
-COPY patch-lib-analyzer-${VULAS_RELEASE}-jar-with-dependencies.jar /vulas/patch-lib-analyzer.jar
-COPY run.sh /vulas/run.sh
+COPY patch-lib-analyzer-${VULAS_RELEASE}-jar-with-dependencies.jar /steady/patch-lib-analyzer.jar
+COPY run.sh /steady/run.sh
 
-RUN chmod +x /vulas/run.sh
+RUN chmod +x /steady/run.sh
 
-CMD ["/vulas/run.sh"]
+CMD ["/steady/run.sh"]

--- a/docker/rest-backend/Dockerfile
+++ b/docker/rest-backend/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:11-jre-slim
+# https://hub.docker.com/layers/eclipse-temurin/library/eclipse-temurin/11.0.15_10-jre/images/sha256-1543416e05e9fde8ffede76cd5f0955b640d7159bdbff8574eed6560a98e4ad3?context=explore
+FROM eclipse-temurin@sha256:1543416e05e9fde8ffede76cd5f0955b640d7159bdbff8574eed6560a98e4ad3
 
 LABEL maintainer="steady-dev@eclipse.org"
 
@@ -10,12 +11,12 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
-COPY rest-backend-$VULAS_RELEASE.jar /vulas/rest-backend.jar
-COPY run.sh /vulas/run.sh
+COPY rest-backend-$VULAS_RELEASE.jar /steady/rest-backend.jar
+COPY run.sh /steady/run.sh
 RUN touch /$VULAS_RELEASE
 
 EXPOSE 8091
 
-RUN chmod +x /vulas/run.sh
+RUN chmod +x /steady/run.sh
 
-CMD ["/vulas/run.sh"]
+CMD ["/steady/run.sh"]

--- a/docker/rest-lib-utils/Dockerfile
+++ b/docker/rest-lib-utils/Dockerfile
@@ -1,12 +1,13 @@
-FROM openjdk:11-jre-slim
+# https://hub.docker.com/layers/eclipse-temurin/library/eclipse-temurin/11.0.15_10-jre/images/sha256-1543416e05e9fde8ffede76cd5f0955b640d7159bdbff8574eed6560a98e4ad3?context=explore
+FROM eclipse-temurin@sha256:1543416e05e9fde8ffede76cd5f0955b640d7159bdbff8574eed6560a98e4ad3
 
 LABEL maintainer="steady-dev@eclipse.org"
 
 ARG VULAS_RELEASE
 
-COPY rest-lib-utils-${VULAS_RELEASE}.jar /vulas/rest-lib-utils.jar
+COPY rest-lib-utils-${VULAS_RELEASE}.jar /steady/rest-lib-utils.jar
 RUN touch /$VULAS_RELEASE
 
 EXPOSE 8092
 
-CMD java -Dhttp.nonProxyHosts=${NON_PROXY_HOSTS} -Dhttps.nonProxyHosts=${NON_PROXY_HOSTS} -Dhttps.proxyHost=${HTTPS_PROXY_HOST} -Dhttps.proxyPort=${HTTP_PROXY_PORT} -Dhttp.proxyHost=${HTTP_PROXY_HOST} -Dhttp.proxyPort=${HTTP_PROXY_PORT} -jar /vulas/rest-lib-utils.jar
+CMD java -Dhttp.nonProxyHosts=${NON_PROXY_HOSTS} -Dhttps.nonProxyHosts=${NON_PROXY_HOSTS} -Dhttps.proxyHost=${HTTPS_PROXY_HOST} -Dhttps.proxyPort=${HTTP_PROXY_PORT} -Dhttp.proxyHost=${HTTP_PROXY_HOST} -Dhttp.proxyPort=${HTTP_PROXY_PORT} -jar /steady/rest-lib-utils.jar


### PR DESCRIPTION
<!-- Describe your contribution -->
- Upgrade main modules Docker images. 
- Fixes images to specific digest. 
- Switches from `openjdk` images to `temurin` images.

`temurin` images are baked by Eclipse and provide long-term support. `openjdk` doesn't provide LTS. 
<!-- Check if you tested/documented your contribution -->
I haven't tested my solution. Hopefully, the CI will do.
#### `TODO`s

- [ ] Tests
- [ ] Documentation