### PR TITLE
fix: encoding issues in german i18n file

### DIFF
--- a/frontend-apps/src/main/webapp/i18n/messageBundle_de.properties
+++ b/frontend-apps/src/main/webapp/i18n/messageBundle_de.properties
@@ -26,10 +26,10 @@ MasterTableVersionColumn=Version
 masterSearchPlaceholder=Suchen...
 masterSearchTooltip=Suche nach Group ID, Artifact ID oder Version
 
-Archives=Abh�ngigkeiten
+Archives=Abhängigkeiten
 patchAnalysis=Schwachstellen
-mavenVerified=Bestaetigtes Maven Archiv
-testCoverageTitle=Testabdeckung f�r 
+mavenVerified=Bestätigtes Maven Archiv
+testCoverageTitle=Testabdeckung für
 archivesTC=Archive
 GoalExecutions=Historie
 mitigation=Reparatur
@@ -37,7 +37,7 @@ mitigation=Reparatur
 # Dependencies
 wellknownDigest=Bekannter Digest
 digestTimestamp=Releasedatum
-declaredDependency=Deklarierte Abh�ngigkeit
+declaredDependency=Deklarierte Abhängigkeit
 
 # Test Coverage / Statistics
 testCoverage=Statistiken
@@ -45,12 +45,12 @@ testCoverage=Statistiken
 # Ratio table
 ratioConstructType=Konstrukttyp
 ratioConstructApp=Anwendung
-ratioConstructDeps=Total (Anwendung + Abh�ngigkeiten)
+ratioConstructDeps=Total (Anwendung + Abhängigkeiten)
 ratioConstructRatio=Prozent (Anwendung/Total)
 # Metric names coming from the backend service
 class_ratio=Klassen
 package_ratio=Pakete
-executable_ratio=Ausf�hrbare Konstrukte (Methoden, Konstruktoren, statische Initialisierer)
+executable_ratio=Ausführbare Konstrukte (Methoden, Konstruktoren, statische Initialisierer)
 
 # Test coverage table
 packages=Anwendungspaket


### PR DESCRIPTION
Using steady inside a browser with german language config looks a little bit.. ugly 😅

![grafik](https://user-images.githubusercontent.com/999748/177563466-9619f5de-aaf5-4f98-97c7-09e90d1f1c3f.png)

Therefore I decided to quickly fix this.