### PR TITLE
SBOM creation with prepare-release profile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,14 +81,14 @@ spec:
       }
     }
     // Verifies that the -javadoc and -sources artifacts can be generated (by enabling the
-    // javadoc profile contained in three pom.xml files). Also verifies that the build
+    // prepare-release profile contained in three pom.xml files). Also verifies that the build
     // is reproducible, and that Spotbugs checks do not fail (cf.
     // https://eclipse.github.io/steady/contributor/#contribution-content-guidelines).
-    stage('Create javadoc + sources, Verify Spotbugs and Reproducibility') {
+    stage('Create javadoc + sources + CycloneDX BOM, Verify Spotbugs and Reproducibility') {
       steps {
         container('maven') {
           sh 'export MAVEN_OPTS="-Xms4g -Xmx8g"'
-          sh 'mvn -B -e -P gradle,javadoc \
+          sh 'mvn -B -e -P gradle,prepare-release \
                   -Dspring.standalone \
                   -DskipTests \
                   -Dvulas.shared.m2Dir=/home/jenkins/agent/workspace \
@@ -96,7 +96,7 @@ spec:
                   -Dspotbugs.includeFilterFile=findbugs-include.xml \
                   -Dspotbugs.failOnError=true \
                   clean install com.github.spotbugs:spotbugs-maven-plugin:4.2.3:check'
-          // sh 'mvn -B -e -P javadoc \
+          // sh 'mvn -B -e -P prepare-release \
           //         -Dspring.standalone \
           //         -DskipTests \
           //         -Dreference.repo=https://repo.maven.apache.org/maven2 \
@@ -132,7 +132,7 @@ spec:
             sh 'gpg --batch --import "${KEYRING}"'
             sh 'for fpr in $(gpg --list-keys --with-colons  | awk -F: \'/fpr:/ {print $10}\' | sort -u); do echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key ${fpr} trust; done'
           }
-          sh 'mvn -B -e -P gradle,javadoc,release \
+          sh 'mvn -B -e -P gradle,prepare-release,release \
                   -Dspring.standalone \
                   -DskipTests \
                   clean deploy'

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
 
 		<!-- Activate when deploying to the Central Repo. Also see https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release -->
 		<profile>
-			<id>javadoc</id>
+			<id>prepare-release</id>
 			<build>
 				<plugins>
 					<plugin>
@@ -219,6 +219,17 @@
 								</goals>
 							</execution>
 						</executions>
+					</plugin>
+					<plugin>
+							<groupId>org.cyclonedx</groupId>
+							<artifactId>cyclonedx-maven-plugin</artifactId>
+							<version>2.7.1</version>
+							<executions>
+							<execution>
+								<phase>package</phase>
+								<goals><goal>makeAggregateBom</goal></goals>
+							</execution>
+							</executions>
 					</plugin>
 				</plugins>
 			</build>
@@ -697,20 +708,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			
-			<plugin>
-					<groupId>org.cyclonedx</groupId>
-					<artifactId>cyclonedx-maven-plugin</artifactId>
-					<version>2.6.2</version>
-					<executions>
-					<execution>
-						<phase>package</phase>
-						<goals><goal>makeAggregateBom</goal></goals>
-					</execution>
-					</executions>
-			</plugin>
-
-
 		</plugins>
 
 		<pluginManagement>

--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -327,7 +327,7 @@
 
 		<!-- Activate when deploying to the Central Repo. Also see https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release -->
 		<profile>
-			<id>javadoc</id>
+			<id>prepare-release</id>
 			<build>
 				<plugins>
 					<plugin>
@@ -357,6 +357,17 @@
 								</goals>
 							</execution>
 						</executions>
+					</plugin>
+					<plugin>
+							<groupId>org.cyclonedx</groupId>
+							<artifactId>cyclonedx-maven-plugin</artifactId>
+							<version>2.7.1</version>
+							<executions>
+							<execution>
+								<phase>package</phase>
+								<goals><goal>makeAggregateBom</goal></goals>
+							</execution>
+							</executions>
 					</plugin>
 				</plugins>
 			</build>

--- a/rest-lib-utils/pom.xml
+++ b/rest-lib-utils/pom.xml
@@ -311,7 +311,7 @@
 
 		<!-- Activate when deploying to the Central Repo. Also see https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release -->
 		<profile>
-			<id>javadoc</id>
+			<id>prepare-release</id>
 			<build>
 				<plugins>
 					<plugin>
@@ -341,6 +341,17 @@
 								</goals>
 							</execution>
 						</executions>
+					</plugin>
+					<plugin>
+							<groupId>org.cyclonedx</groupId>
+							<artifactId>cyclonedx-maven-plugin</artifactId>
+							<version>2.7.1</version>
+							<executions>
+							<execution>
+								<phase>package</phase>
+								<goals><goal>makeAggregateBom</goal></goals>
+							</execution>
+							</executions>
 					</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
SBOM are not created during every build, but only if the `prepare-release` profile is enabled (formerly called `javadoc`). The `Jenkinsfile`has been adjusted accordingly. Finally, the `cyclonedx-maven-plugin` has also been added to the modules `rest-backend` and `rest-lib-utils`, and updated to version 2.7.1.

To test the SBOM generation for all 18 modules and the aggregator, run `mvn -DskipTests -Dspring.standalone clean install -P prepare-release,gradle`, and check whether the SBOM have been installed in the local M2 folder.