### PR TITLE
Replaced FileUtil.copyFile by more generic FileUtil.copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ google-java-format-*.jar
 docker/kb-importer/data/**
 **/*.buildinfo
 docker/kb-importer/data/**
+
+java-files.txt
+non-compliant-files.txt

--- a/plugin-maven/src/main/java/org/eclipse/steady/java/mvn/MvnPluginInstr.java
+++ b/plugin-maven/src/main/java/org/eclipse/steady/java/mvn/MvnPluginInstr.java
@@ -62,8 +62,8 @@ public class MvnPluginInstr extends AbstractVulasMojo {
     final Path lib_dir = this.vulasConfiguration.getDir(CoreConfiguration.INSTR_LIB_DIR);
     final Path incl_dir = this.vulasConfiguration.getDir(CoreConfiguration.INSTR_INCLUDE_DIR);
 
-    final Path incl_agent = FileUtil.copyFile(this.getAgentJarFile().toPath(), incl_dir);
-    final Path lib_agent = FileUtil.copyFile(this.getAgentJarFile().toPath(), lib_dir);
+    final Path incl_agent = FileUtil.copy(this.getAgentJarFile().toPath(), incl_dir, null);
+    final Path lib_agent = FileUtil.copy(this.getAgentJarFile().toPath(), lib_dir, null);
 
     getLog()
         .info(

--- a/shared/src/main/java/org/eclipse/steady/shared/util/FileUtil.java
+++ b/shared/src/main/java/org/eclipse/steady/shared/util/FileUtil.java
@@ -24,7 +24,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -282,44 +281,52 @@ public class FileUtil {
    * existing file nor directory or the target folder does not exist.
    */
   public static Path copy(Path _source, Path _target_dir, Path _target_name, CopyOption... options)
-    throws IOException, IllegalArgumentException {
+      throws IOException, IllegalArgumentException {
 
     // Check args
-    if(!FileUtil.isAccessibleFile(_source) && !FileUtil.isAccessibleDirectory(_source)) {
+    if (!FileUtil.isAccessibleFile(_source) && !FileUtil.isAccessibleDirectory(_source)) {
       throw new IllegalArgumentException("Source [" + _source + "] does not exist");
-    } else if(!FileUtil.isAccessibleDirectory(_target_dir)) {
-      throw new IllegalArgumentException("Target [" + _target_dir + "] does not exist or is not a directory");
+    } else if (!FileUtil.isAccessibleDirectory(_target_dir)) {
+      throw new IllegalArgumentException(
+          "Target [" + _target_dir + "] does not exist or is not a directory");
     }
 
     Path p = _target_dir.resolve(_target_name == null ? _source.getFileName() : _target_name);
 
     // A single file is copied
-    if(FileUtil.isAccessibleFile(_source)) {
+    if (FileUtil.isAccessibleFile(_source)) {
       log.info("Copying [" + _source + "] to [" + p + "]");
       Files.copy(_source, p, options);
     }
     // A directory is copied
-    else if(FileUtil.isAccessibleDirectory(_source)) {
-      Files.walkFileTree(_source, new SimpleFileVisitor<Path>() {
-          @Override
-          public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
-                  throws IOException {
-              Path p = _target_dir.resolve(_target_name == null ? _source.getFileName() : _target_name).resolve(_source.relativize(dir));
+    else if (FileUtil.isAccessibleDirectory(_source)) {
+      Files.walkFileTree(
+          _source,
+          new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                throws IOException {
+              Path p =
+                  _target_dir
+                      .resolve(_target_name == null ? _source.getFileName() : _target_name)
+                      .resolve(_source.relativize(dir));
               log.debug("Visiting dir [" + dir + "], creating dir [" + p + "]");
               Files.createDirectories(p);
               return FileVisitResult.CONTINUE;
-          }
+            }
 
-          @Override
-          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                  throws IOException {
-              Path p = _target_dir.resolve(_target_name == null ? _source.getFileName() : _target_name).resolve(_source.relativize(file));
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                throws IOException {
+              Path p =
+                  _target_dir
+                      .resolve(_target_name == null ? _source.getFileName() : _target_name)
+                      .resolve(_source.relativize(file));
               log.debug("Visiting file [" + file + "], copying to [" + p + "]");
               Files.copy(file, p, options);
               return FileVisitResult.CONTINUE;
-          }
-        }
-      );
+            }
+          });
     }
 
     return p;

--- a/shared/src/main/java/org/eclipse/steady/shared/util/FileUtil.java
+++ b/shared/src/main/java/org/eclipse/steady/shared/util/FileUtil.java
@@ -30,6 +30,10 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.Charset;
+import java.nio.file.FileVisitResult;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.CopyOption;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
@@ -267,22 +271,58 @@ public class FileUtil {
   }
 
   /**
-   * <p>copyFile.</p>
+   * Copies the given source file or directory to the given target directory. If
+   * no _target_name is provided, the source will be copied with the identical
+   * name into _target_dir. If _target_name is provided, that name will be
+   * taken.
    *
-   * @param _source_file a {@link java.nio.file.Path} object.
-   * @param _target_dir a {@link java.nio.file.Path} object.
-   * @return a {@link java.nio.file.Path} object.
    * @throws java.io.IOException if any.
+   * @throws java.lang.InterruptedException if any.
+   * @throws java.lang.IllegalArgumentException if _source is neither an
+   * existing file nor directory or the target folder does not exist.
    */
-  public static Path copyFile(Path _source_file, Path _target_dir) throws IOException {
-    final Path to = _target_dir.resolve(_source_file.getFileName());
-    try (final InputStream is = new FileInputStream(_source_file.toFile());
-        final OutputStream os = new FileOutputStream(to.toFile())) {
-      final byte[] byte_buffer = new byte[1024];
-      int len = 0;
-      while ((len = is.read(byte_buffer)) != -1) os.write(byte_buffer, 0, len);
+  public static Path copy(Path _source, Path _target_dir, Path _target_name, CopyOption... options)
+    throws IOException, IllegalArgumentException {
+
+    // Check args
+    if(!FileUtil.isAccessibleFile(_source) && !FileUtil.isAccessibleDirectory(_source)) {
+      throw new IllegalArgumentException("Source [" + _source + "] does not exist");
+    } else if(!FileUtil.isAccessibleDirectory(_target_dir)) {
+      throw new IllegalArgumentException("Target [" + _target_dir + "] does not exist or is not a directory");
     }
-    return to;
+
+    Path p = _target_dir.resolve(_target_name == null ? _source.getFileName() : _target_name);
+
+    // A single file is copied
+    if(FileUtil.isAccessibleFile(_source)) {
+      log.info("Copying [" + _source + "] to [" + p + "]");
+      Files.copy(_source, p, options);
+    }
+    // A directory is copied
+    else if(FileUtil.isAccessibleDirectory(_source)) {
+      Files.walkFileTree(_source, new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                  throws IOException {
+              Path p = _target_dir.resolve(_target_name == null ? _source.getFileName() : _target_name).resolve(_source.relativize(dir));
+              log.debug("Visiting dir [" + dir + "], creating dir [" + p + "]");
+              Files.createDirectories(p);
+              return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                  throws IOException {
+              Path p = _target_dir.resolve(_target_name == null ? _source.getFileName() : _target_name).resolve(_source.relativize(file));
+              log.debug("Visiting file [" + file + "], copying to [" + p + "]");
+              Files.copy(file, p, options);
+              return FileVisitResult.CONTINUE;
+          }
+        }
+      );
+    }
+
+    return p;
   }
 
   // Reading files

--- a/shared/src/main/java/org/eclipse/steady/shared/util/FileUtil.java
+++ b/shared/src/main/java/org/eclipse/steady/shared/util/FileUtil.java
@@ -276,9 +276,13 @@ public class FileUtil {
    * taken.
    *
    * @throws java.io.IOException if any.
-   * @throws java.lang.InterruptedException if any.
    * @throws java.lang.IllegalArgumentException if _source is neither an
    * existing file nor directory or the target folder does not exist.
+   * @param _source a path to the source file
+   * @param _target_dir a path to the target file
+   * @param _target_name a name of the target file or directory (optional)
+   * @param options a {@link java.nio.file.CopyOption} object
+   * @return a {@link java.nio.file.Path} object to the target
    */
   public static Path copy(Path _source, Path _target_dir, Path _target_name, CopyOption... options)
       throws IOException, IllegalArgumentException {
@@ -494,6 +498,7 @@ public class FileUtil {
 
   /**
    * Returns the CRC-32 checksum for the given byte array.
+   *
    * @param _bytes a byte array
    * @return the CRC-32 checksum of the array
    */
@@ -506,6 +511,7 @@ public class FileUtil {
   /**
    * Returns the CRC-32 checksum for the given {@link File}.
    * Returns -1 if the checksum cannot be computed.
+   *
    * @param _file a file
    * @return the CRC-32 checksum of the file
    */

--- a/shared/src/main/java/org/eclipse/steady/shared/util/VulasConfiguration.java
+++ b/shared/src/main/java/org/eclipse/steady/shared/util/VulasConfiguration.java
@@ -293,6 +293,7 @@ public class VulasConfiguration {
   /**
    * Removes keys not matching the regular expression {@link KEY_PATTERN} from
    * the configuration.
+   *
    * @param _cfg the configuration whose keys are checked
    */
   public void sanitize(Configuration _cfg) {

--- a/shared/src/test/java/org/eclipse/steady/shared/util/FileUtilTest.java
+++ b/shared/src/test/java/org/eclipse/steady/shared/util/FileUtilTest.java
@@ -74,7 +74,8 @@ public class FileUtilTest {
       Path source = Paths.get("./src/test/resources/foo.txt");
       Path target_dir = Paths.get("./target");
       Path target_name = null;
-      Path target = FileUtil.copy(source, target_dir, target_name, StandardCopyOption.REPLACE_EXISTING);
+      Path target =
+          FileUtil.copy(source, target_dir, target_name, StandardCopyOption.REPLACE_EXISTING);
       assertTrue(FileUtil.isAccessibleFile("./target/foo.txt"));
       assertEquals(
           FileUtil.getDigest(source.toFile(), DigestAlgorithm.SHA1),

--- a/shared/src/test/java/org/eclipse/steady/shared/util/FileUtilTest.java
+++ b/shared/src/test/java/org/eclipse/steady/shared/util/FileUtilTest.java
@@ -28,6 +28,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
+import java.nio.file.StandardCopyOption;
 
 import org.eclipse.steady.shared.enums.DigestAlgorithm;
 import org.junit.Test;
@@ -67,18 +68,46 @@ public class FileUtilTest {
   }
 
   @Test
-  public void testCopyFile() {
+  public void testCopy() {
     try {
-      final VulasConfiguration cfg = new VulasConfiguration();
-      final Path tmp_dir = cfg.getTmpDir();
-      final Path source_file = Paths.get("./src/test/resources/Outer.jar");
-      final Path target_file = FileUtil.copyFile(source_file, tmp_dir);
+      // Copy file and keep name
+      Path source = Paths.get("./src/test/resources/foo.txt");
+      Path target_dir = Paths.get("./target");
+      Path target_name = null;
+      Path target = FileUtil.copy(source, target_dir, target_name, StandardCopyOption.REPLACE_EXISTING);
+      assertTrue(FileUtil.isAccessibleFile("./target/foo.txt"));
       assertEquals(
-          FileUtil.getDigest(source_file.toFile(), DigestAlgorithm.SHA1),
-          FileUtil.getDigest(target_file.toFile(), DigestAlgorithm.SHA1));
+          FileUtil.getDigest(source.toFile(), DigestAlgorithm.SHA1),
+          FileUtil.getDigest(target.toFile(), DigestAlgorithm.SHA1));
+
+      // Copy file and change name
+      source = Paths.get("./src/test/resources/foo.txt");
+      target_dir = Paths.get("./target");
+      target_name = Paths.get("bar.txt");
+      target = FileUtil.copy(source, target_dir, target_name, StandardCopyOption.REPLACE_EXISTING);
+      assertTrue(FileUtil.isAccessibleFile("./target/bar.txt"));
+      assertEquals(
+          FileUtil.getDigest(source.toFile(), DigestAlgorithm.SHA1),
+          FileUtil.getDigest(target.toFile(), DigestAlgorithm.SHA1));
+
+      // Copy dir and keep name
+      source = Paths.get("./src/test/resources/foo");
+      target_dir = Paths.get("./target");
+      target_name = null;
+      target = FileUtil.copy(source, target_dir, target_name, StandardCopyOption.REPLACE_EXISTING);
+      assertTrue(FileUtil.isAccessibleFile("./target/foo/bar/bar.baz"));
+      assertTrue(FileUtil.isAccessibleDirectory("./target/foo/bar"));
+
+      // Copy dir and change name
+      source = Paths.get("./src/test/resources/foo");
+      target_dir = Paths.get("./target");
+      target_name = Paths.get("baz");
+      target = FileUtil.copy(source, target_dir, target_name, StandardCopyOption.REPLACE_EXISTING);
+      assertTrue(FileUtil.isAccessibleFile("./target/baz/bar/bar.baz"));
+      assertTrue(FileUtil.isAccessibleDirectory("./target/baz/bar"));
     } catch (IOException e) {
       e.printStackTrace();
-      assertEquals(true, false);
+      assertTrue(false);
     }
   }
 


### PR DESCRIPTION
`FileUtil.copy`allows copying directories, which was not possible with the previous method `copyFile`.

#### `TODO`s

- [x] Tests
- [x] Documentation