### PR TITLE
Use Docker tags instead of arch. specific digests

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ Other limitations:
 
 - Static and dynamic analyses are not implemented for Python
 - Java 9 multi-release archives are not supported (classes below `META-INF/versions` are simply ignored)
-- Docker containers crash on Apple M1
 
 ## Acknowledgement 
 

--- a/docker/frontend-apps/Dockerfile
+++ b/docker/frontend-apps/Dockerfile
@@ -1,5 +1,4 @@
-# https://hub.docker.com/layers/jetty/library/jetty/9.4.46-jdk11-alpine-eclipse-temurin/images/sha256-dcaab143043b8916675f8533700c07310986e94db9ee4f2f6bf336e8befc53e9?context=explore
-FROM jetty@sha256:dcaab143043b8916675f8533700c07310986e94db9ee4f2f6bf336e8befc53e9
+FROM jetty:9.4.49-jdk11-eclipse-temurin
 
 LABEL maintainer="steady-dev@eclipse.org"
 

--- a/docker/frontend-bugs/Dockerfile
+++ b/docker/frontend-bugs/Dockerfile
@@ -1,5 +1,4 @@
-# https://hub.docker.com/layers/jetty/library/jetty/9.4.46-jdk11-alpine-eclipse-temurin/images/sha256-dcaab143043b8916675f8533700c07310986e94db9ee4f2f6bf336e8befc53e9?context=explore
-FROM jetty@sha256:dcaab143043b8916675f8533700c07310986e94db9ee4f2f6bf336e8befc53e9
+FROM jetty:9.4.49-jdk11-eclipse-temurin
 
 LABEL maintainer="steady-dev@eclipse.org"
 

--- a/docker/kb-importer/Dockerfile
+++ b/docker/kb-importer/Dockerfile
@@ -1,5 +1,4 @@
-# https://hub.docker.com/layers/library/eclipse-temurin/11.0.16.1_1-jre/images/sha256-ba66fe69ca119df55837f1e1185a242912ebb67431b332c67b153a8dbbe42106?context=explore
-FROM eclipse-temurin@sha256:ba66fe69ca119df55837f1e1185a242912ebb67431b332c67b153a8dbbe42106
+FROM eclipse-temurin:11.0.16.1_1-jre
 
 LABEL maintainer="steady-dev@eclipse.org"
 

--- a/docker/patch-lib-analyzer/Dockerfile
+++ b/docker/patch-lib-analyzer/Dockerfile
@@ -1,5 +1,4 @@
-# https://hub.docker.com/layers/library/eclipse-temurin/11.0.16.1_1-jre/images/sha256-ba66fe69ca119df55837f1e1185a242912ebb67431b332c67b153a8dbbe42106?context=explore
-FROM eclipse-temurin@sha256:ba66fe69ca119df55837f1e1185a242912ebb67431b332c67b153a8dbbe42106
+FROM eclipse-temurin:11.0.16.1_1-jre
 
 LABEL maintainer="steady-dev@eclipse.org"
 

--- a/docker/rest-backend/Dockerfile
+++ b/docker/rest-backend/Dockerfile
@@ -1,5 +1,4 @@
-# https://hub.docker.com/layers/library/eclipse-temurin/11.0.16.1_1-jre/images/sha256-ba66fe69ca119df55837f1e1185a242912ebb67431b332c67b153a8dbbe42106?context=explore
-FROM eclipse-temurin@sha256:ba66fe69ca119df55837f1e1185a242912ebb67431b332c67b153a8dbbe42106
+FROM eclipse-temurin:11.0.16.1_1-jre
 
 LABEL maintainer="steady-dev@eclipse.org"
 

--- a/docker/rest-lib-utils/Dockerfile
+++ b/docker/rest-lib-utils/Dockerfile
@@ -1,5 +1,4 @@
-# https://hub.docker.com/layers/library/eclipse-temurin/11.0.16.1_1-jre/images/sha256-ba66fe69ca119df55837f1e1185a242912ebb67431b332c67b153a8dbbe42106?context=explore
-FROM eclipse-temurin@sha256:ba66fe69ca119df55837f1e1185a242912ebb67431b332c67b153a8dbbe42106
+FROM eclipse-temurin:11.0.16.1_1-jre
 
 LABEL maintainer="steady-dev@eclipse.org"
 


### PR DESCRIPTION
The advantage of using tags is that Docker fetches the image according to the architecture in place (provided it exists), rather than downloading the image pinned with the digest, which may not match to the architecture. 

#### `TODO`s

- [ ] Tests
- [ ] Documentation