### PR TITLE
Fixes a bug in the mitigation tab

### DIFF
--- a/docker/rest-backend/run.sh
+++ b/docker/rest-backend/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-FLYWAY_OPTS="-Dflyway.skipDefaultCallbacks=true" 
+FLYWAY_OPTS="-Dflyway.skipDefaultCallbacks=true"
 
 if [ "x$DELAY_STARTUP" != "x"  ];
 then
@@ -19,5 +19,6 @@ java \
     -Dvulas.jira.usr=$JIRA_USER \
     -Dvulas.jira.pwd=$JIRA_PASSWORD \
     $FLYWAY_OPTS \
+    $DEBUG_OPTS \
     -Dspring.profiles.active=docker \
 	-jar /steady/rest-backend.jar

--- a/rest-backend/src/main/java/org/eclipse/steady/backend/model/Library.java
+++ b/rest-backend/src/main/java/org/eclipse/steady/backend/model/Library.java
@@ -461,7 +461,7 @@ public class Library implements Serializable {
    * @return a {@link org.eclipse.steady.backend.model.ConstructIdFilter} object.
    */
   @JsonProperty(value = "constructTypeCounters")
-  @JsonView(Views.Default.class)
+  @JsonView(Views.CountDetails.class)
   @JsonIgnoreProperties(
       value = {"constructTypeCounters"},
       allowGetters = true)

--- a/rest-backend/src/main/java/org/eclipse/steady/backend/model/view/Views.java
+++ b/rest-backend/src/main/java/org/eclipse/steady/backend/model/view/Views.java
@@ -35,7 +35,7 @@ package org.eclipse.steady.backend.model.view;
  */
 public class Views {
 
-  public interface Default {}
+  public interface Default extends CountDetails {}
 
   public interface BugDetails {}
 


### PR DESCRIPTION
The default view does not return the construct counters, which makes the mitigation tab fail.

Also added DEBUG_OPTS to backend's `run.sh` script, which can be specified in `docker-compose.yml` as follows (if debugging is needed).

```
    ports:
      - "8000:8000"
    environment:
      - DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000
```

#### `TODO`s

- [ ] Tests
- [ ] Documentation