### PR TITLE
Update deps

### DIFF
--- a/lang-java-reach-soot/pom.xml
+++ b/lang-java-reach-soot/pom.xml
@@ -87,7 +87,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>30.1.1-jre</version>
+			<version>31.1-jre</version>
 		</dependency>
 	</dependencies>
 	

--- a/plugin-maven/pom.xml
+++ b/plugin-maven/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.10.12</version>
+            <version>1.10.13</version>
         </dependency>
 
         <!-- Instrumentation agent dependency -->

--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
 			<dependency>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-runtime</artifactId>
-				<version>4.11.1</version>
+				<version>4.9.2</version>
 			</dependency>
 			<dependency>
 				<groupId>com.github.package-url</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -301,17 +301,17 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.18.0</version>
+			<version>2.19.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.18.0</version>
+			<version>2.19.0</version>
 		</dependency>
 		<dependency>
   			<groupId>com.github.spotbugs</groupId>
   			<artifactId>spotbugs-annotations</artifactId>
-  			<version>4.7.2</version>
+  			<version>4.7.3</version>
 		</dependency>
 	</dependencies>
 
@@ -321,12 +321,12 @@
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
-				<version>4.5.13</version>
+				<version>4.5.14</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-cli</groupId>
 				<artifactId>commons-cli</artifactId>
-				<version>1.4</version>
+				<version>1.5.0</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-configuration</groupId>
@@ -346,7 +346,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-compress</artifactId>
-				<version>1.21</version>
+				<version>1.22</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-beanutils</groupId>
@@ -356,17 +356,17 @@
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>2.9.0</version>
+				<version>2.10.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.javassist</groupId>
 				<artifactId>javassist</artifactId>
-				<version>3.28.0-GA</version>
+				<version>3.29.2-GA</version>
 			</dependency>
 			<dependency>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-runtime</artifactId>
-				<version>4.9.3</version>
+				<version>4.11.1</version>
 			</dependency>
 			<dependency>
 				<groupId>com.github.package-url</groupId>
@@ -378,17 +378,17 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-core</artifactId>
-				<version>2.13.4</version>
+				<version>2.14.2</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>2.13.4</version>
+				<version>2.14.2</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-annotations</artifactId>
-				<version>2.13.4</version>
+				<version>2.14.2</version>
 			</dependency>
 
 			<!-- Versions of 'org.apache.maven' artifacts should be identical -->
@@ -412,7 +412,7 @@
 			<dependency>
 				<groupId>com.xebialabs.restito</groupId>
 				<artifactId>restito</artifactId>
-				<version>0.9.4</version>
+				<version>1.1.0</version>
 			</dependency>
 			<dependency>
 				<groupId>com.jayway.restassured</groupId>
@@ -769,7 +769,7 @@
 						<dependency>
 							<groupId>org.apache.maven.wagon</groupId>
 							<artifactId>wagon-file</artifactId>
-							<version>3.5.1</version>
+							<version>3.5.3</version>
 						</dependency>
 					</dependencies>
 				</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
 			<dependency>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-runtime</artifactId>
-				<version>4.9.2</version>
+				<version>4.10.1</version>
 			</dependency>
 			<dependency>
 				<groupId>com.github.package-url</groupId>
@@ -811,7 +811,7 @@
 				<plugin>
 					<groupId>org.antlr</groupId>
 					<artifactId>antlr4-maven-plugin</artifactId>
-					<version>4.9.2</version>
+					<version>4.10.1</version>
 					<executions>
 						<execution>
 							<id>generate-antlr4</id>

--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
 			<dependency>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-runtime</artifactId>
-				<version>4.10.1</version>
+				<version>4.11.1</version>
 			</dependency>
 			<dependency>
 				<groupId>com.github.package-url</groupId>
@@ -811,7 +811,7 @@
 				<plugin>
 					<groupId>org.antlr</groupId>
 					<artifactId>antlr4-maven-plugin</artifactId>
-					<version>4.10.1</version>
+					<version>4.11.1</version>
 					<executions>
 						<execution>
 							<id>generate-antlr4</id>

--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.8</version>
+		<version>2.5.14</version>
 		<relativePath />
 	</parent>
 

--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -183,7 +183,7 @@
 		<dependency>
 		    <groupId>com.google.guava</groupId>
 		    <artifactId>guava</artifactId>
-		    <version>30.0-jre</version>
+		    <version>31.1-jre</version>
 		</dependency>
 
 		<!-- Test dependencies -->

--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.12</version>
+		<version>2.7.8</version>
 		<relativePath />
 	</parent>
 
@@ -148,12 +148,12 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
-			<version>1.21</version>
+			<version>1.22</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.13</version>
+			<version>4.5.14</version>
 		</dependency>
 		<dependency>
 			<groupId>com.jayway.jsonpath</groupId>
@@ -217,7 +217,7 @@
 		<dependency>
 			<groupId>com.xebialabs.restito</groupId>
 			<artifactId>restito</artifactId>
-			<version>0.9.4</version>
+			<version>1.1.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -272,7 +272,7 @@
 				<dependency>
 					<groupId>org.postgresql</groupId>
 					<artifactId>postgresql</artifactId>
-					<version>42.4.2</version>
+					<version>42.5.3</version>
 				</dependency>
 			</dependencies>
 		</profile>

--- a/rest-lib-utils/pom.xml
+++ b/rest-lib-utils/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.12</version>
+		<version>2.7.8</version>
 		<relativePath/>
 	</parent>
 
@@ -161,12 +161,12 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.13</version>
+			<version>4.5.14</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.7</version>
+			<version>2.11.0</version>
 		</dependency>
 
 		<!-- Swagger dependencies -->
@@ -175,15 +175,15 @@
 	      <artifactId>springdoc-openapi-ui</artifactId>
 	      <version>1.2.32</version>
 	   </dependency>
-        
+        <!-- type=test-jar does not seem to work here, use classifier instead -->
 		<!-- Test dependencies -->
-		<dependency>
+		<!-- <dependency>
 			<groupId>org.eclipse.steady</groupId>
 			<artifactId>shared</artifactId>
-			<classifier>tests</classifier> <!-- type=test-jar does not seem to work here, use classifier instead -->
+			<classifier>tests</classifier> 
 			<version>${project.version}</version>
 			<scope>test</scope>
-		</dependency>
+		</dependency> -->
 		<dependency>
 		 	<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -224,7 +224,7 @@
 		<dependency>
 			<groupId>org.apache.ant</groupId>
 			<artifactId>ant</artifactId>
-			<version>1.10.12</version>
+			<version>1.10.13</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/rest-lib-utils/pom.xml
+++ b/rest-lib-utils/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.14</version>
+		<version>2.7.8</version>
 		<relativePath/>
 	</parent>
 
@@ -173,7 +173,7 @@
 		<dependency>
 	      <groupId>org.springdoc</groupId>
 	      <artifactId>springdoc-openapi-ui</artifactId>
-	      <version>1.2.32</version>
+	      <version>1.6.10</version>
 	   </dependency>
         
 		<!-- Test dependencies -->

--- a/rest-lib-utils/pom.xml
+++ b/rest-lib-utils/pom.xml
@@ -173,7 +173,7 @@
 		<dependency>
 	      <groupId>org.springdoc</groupId>
 	      <artifactId>springdoc-openapi-ui</artifactId>
-	      <version>1.6.10</version>
+	      <version>1.6.14</version>
 	   </dependency>
         
 		<!-- Test dependencies -->
@@ -214,7 +214,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>30.1.1-jre</version>
+			<version>31.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>

--- a/rest-lib-utils/pom.xml
+++ b/rest-lib-utils/pom.xml
@@ -175,15 +175,15 @@
 	      <artifactId>springdoc-openapi-ui</artifactId>
 	      <version>1.2.32</version>
 	   </dependency>
-        <!-- type=test-jar does not seem to work here, use classifier instead -->
+        
 		<!-- Test dependencies -->
-		<!-- <dependency>
+		<dependency>
 			<groupId>org.eclipse.steady</groupId>
 			<artifactId>shared</artifactId>
-			<classifier>tests</classifier> 
+			<classifier>tests</classifier> <!-- type=test-jar does not seem to work here, use classifier instead -->
 			<version>${project.version}</version>
 			<scope>test</scope>
-		</dependency> -->
+		</dependency>
 		<dependency>
 		 	<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/rest-lib-utils/pom.xml
+++ b/rest-lib-utils/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.8</version>
+		<version>2.5.14</version>
 		<relativePath/>
 	</parent>
 

--- a/rest-lib-utils/src/main/java/org/eclipse/steady/cia/rest/MainController.java
+++ b/rest-lib-utils/src/main/java/org/eclipse/steady/cia/rest/MainController.java
@@ -21,9 +21,6 @@ package org.eclipse.steady.cia.rest;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonSerializer;
-
 import org.eclipse.steady.java.sign.ASTConstructBodySignature;
 import org.eclipse.steady.java.sign.ASTSignatureChange;
 import org.eclipse.steady.java.sign.gson.ASTConstructBodySignatureDeserializer;
@@ -41,6 +38,9 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+
 /**
  * <p>MainController class.</p>
  */
@@ -56,7 +56,7 @@ public class MainController extends SpringBootServletInitializer {
    */
   @Bean
   public GroupedOpenApi publicApi() {
-    return GroupedOpenApi.builder().setGroup("public").pathsToMatch("/**").build();
+    return GroupedOpenApi.builder().group("public").pathsToMatch("/**").build();
   }
 
   /**


### PR DESCRIPTION
Updated various dependencies across all modules.

Note: When updating `spring-boot-starter-parent` to 2.6.x and 2.7.x releases, circular references appeared. For `rest-lib-utils`, this was resolved by updating `springdoc-openapi-ui` to 1.6.14. However, this was not sufficient for `rest-backend`, which is why it's only been updated from 2.5.12 to 2.5.14.

#### `TODO`s

- [ ] Tests
- [ ] Documentation