### PR TITLE
Processing of configurations raised issues in Windows

### DIFF
--- a/shared/src/main/java/org/eclipse/steady/shared/util/VulasConfiguration.java
+++ b/shared/src/main/java/org/eclipse/steady/shared/util/VulasConfiguration.java
@@ -306,8 +306,6 @@ public class VulasConfiguration {
       if (!m.matches()) {
         getLog().warn("Configuration key [" + k + "] removed due to illegal characters");
         keys_to_remove.add(k);
-        //_cfg.clearProperty(k);
-        //i.remove();
       }
     }
     for (String p : keys_to_remove) {

--- a/shared/src/main/java/org/eclipse/steady/shared/util/VulasConfiguration.java
+++ b/shared/src/main/java/org/eclipse/steady/shared/util/VulasConfiguration.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -214,7 +215,7 @@ public class VulasConfiguration {
     }
 
     // Add: Environment variables
-    final Map<String, String> env = System.getenv();
+    final Map<String, String> env = new ProcessBuilder().environment();
     Configuration env_config = new MapConfiguration(env);
     addConfiguration(env_config, ENV_CFG_LAYER);
 
@@ -298,13 +299,19 @@ public class VulasConfiguration {
    */
   public void sanitize(Configuration _cfg) {
     final Iterator<String> i = _cfg.getKeys();
+    List<String> keys_to_remove = new ArrayList<String>();
     while (i.hasNext()) {
       final String k = i.next();
       final Matcher m = KEY_PATTERN.matcher(k);
       if (!m.matches()) {
         getLog().warn("Configuration key [" + k + "] removed due to illegal characters");
-        _cfg.clearProperty(k);
+        keys_to_remove.add(k);
+        //_cfg.clearProperty(k);
+        //i.remove();
       }
+    }
+    for (String p : keys_to_remove) {
+      _cfg.clearProperty(p);
     }
   }
 


### PR DESCRIPTION
- environment variables were retrieved using System.getenv(); that returns an unmodifiebleMap thus raising an exception in windows that has `PROGRAMFILES(X86)` among its env variables 
- deletion of values raised ConcurrentModificationException 


Thanks @the-brownstone for reporting and highlighting the issues (see #583)